### PR TITLE
Add `2dboxpml` test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 # Pytest cache
 .cache
 
-# Python 3 cache
+# Python detritus
 **/__pycache__
+**/*.pyc
 
 # Build/run artifacts
 **/*.vtk
@@ -13,6 +14,7 @@
 **/*.output
 **/SESSION.NAME
 **/xxt_map.rea
+**/*.tmp
 
 # Object files
 *.o

--- a/src/maxwell.F
+++ b/src/maxwell.F
@@ -285,10 +285,13 @@ c     sensible.
       real tlorenc_max,tlorenc_min
 
       npts3 = 3*npts
-c     nekuvp returns material properites defined in uservp
-      do ie = 1,nelt
-         call nekuvp(ie)
-      enddo
+c     All the arguments are just dummy arguments. This is a temporary
+c     measure for Maxwell until we move to a system where `uservp` is
+c     called only once and looping is handled in the .usr file. See
+c
+c     https://github.com/NekCEM/NekCEM/issues/12
+c
+      call uservp(1,1,1,1)
 
 c     Check permittivity/permeability setting
       permit_max = glmax(permittivity,npts)

--- a/src/subs1.F
+++ b/src/subs1.F
@@ -270,33 +270,13 @@ C------------------------------------------------------------------
       ENDDO
 
       else
-
-      DO K=1,NZ1
-      DO J=1,NY1
-      DO I=1,NX1
-
-        !CALL NEKASGN (I,J,K,IEL )
-         CALL USERVP  (I,J,K,IELG)
-
-         L=I+nx1*(J-1)+nx1*ny1*(K-1)+nx1*ny1*nz1*(IEL-1)
-
-         PERMITTIVITY(L)= permit
-         PERMEABILITY(L)= permea 
-         DRUDEA(L)   = drude_alpha
-         DRUDEB(L)   = drude_beta
-         LORENA(L,1) = loren_gamma1
-         LORENA(L,2) = loren_gamma2
-         LORENA(L,3) = loren_gamma3
-         LORENB(L,1) = loren_omega1
-         LORENB(L,2) = loren_omega2
-         LORENB(L,3) = loren_omega3
-         LORENC(L,1) = loren_eps1
-         LORENC(L,2) = loren_eps2
-         LORENC(L,3) = loren_eps3
-      ENDDO    
-      ENDDO    
-      ENDDO    
-
+c     We don't use this for Maxwell anymore! Instead `uservp` is called
+c     directly in `maxwell.F`. This part of
+c
+c     https://github.com/NekCEM/NekCEM/issues/12
+c
+         write(*,*) "ERROR: nekuvp: if using Maxwell don't call nekuvp!"
+         stop 1
       endif
 
       RETURN

--- a/tests/2dboxpec/2dboxpec.usr
+++ b/tests/2dboxpec/2dboxpec.usr
@@ -146,24 +146,30 @@ c-----------------------------------------------------------------------
       end
 
 c-----------------------------------------------------------------------
-
-      subroutine uservp (ix,iy,iz,iel)
+      subroutine uservp(ix,iy,iz,iel)
+c-----------------------------------------------------------------------
+      implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
       include 'NEKUSE'
 
-      integer  n, ix, iy, iz, ieg
-      real     one, xcc, ycc, zcc, x1, y1, z1
-      real     lambda, fc, wc
+c     These don't do anything! This is a temporary measure until
+c
+c     https://github.com/NekCEM/NekCEM/issues/12
+c
+c     is resolved.
+      integer ix,iy,iz,iel
 
-      call usermedia   (ix,iy,iz,iel)
+      integer i
 
-      if (IFDRUDE)  call userdrude (ix,iy,iz,iel)
+      do i = 1,npts
+         permittivity(i) = 1.0
+         permeability(i) = 1.0
+      enddo
 
       return
       end
-
 c-----------------------------------------------------------------------
 
       subroutine usermedia(ix,iy,iz,iel) ! Vector form of userf

--- a/tests/2dboxper/2dboxper.usr
+++ b/tests/2dboxper/2dboxper.usr
@@ -132,22 +132,30 @@ c-----------------------------------------------------------------------
       include 'NEKUSE'
       include 'PML'
 
-
       return
       end
 c-----------------------------------------------------------------------
-      subroutine uservp (ix,iy,iz,iel)
+      subroutine uservp(ix,iy,iz,iel)
+c-----------------------------------------------------------------------
+      implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
       include 'NEKUSE'
 
-      integer  n, ix, iy, iz, ieg
-      real     one, xcc, ycc, zcc, x1, y1, z1
-      real     lambda, fc, wc
+c     These don't do anything! This is a temporary measure until
+c
+c     https://github.com/NekCEM/NekCEM/issues/12
+c
+c     is resolved.
+      integer ix,iy,iz,iel
 
-      permea = permea_0
-      permit = permit_0
+      integer i
+
+      do i = 1,npts
+         permittivity(i) = 1.0
+         permeability(i) = 1.0
+      enddo
 
       return
       end

--- a/tests/2dboxpml/2dboxpml.box
+++ b/tests/2dboxpml/2dboxpml.box
@@ -1,0 +1,14 @@
+dummy.rea
+2
+1                      number of fields
+#
+#    comments
+#
+#
+#========================================================
+#
+Box
+-4  -32 (number of elements in x,y)
+-1500  1500   1              (x0,x1,gain)
+-1500  1500   1              (x0,x1,gain)
+P  ,P  ,PML,PML              (bc's)

--- a/tests/2dboxpml/2dboxpml.rea
+++ b/tests/2dboxpml/2dboxpml.rea
@@ -1,0 +1,163 @@
+ ****** PARAMETERS *****
+    2.610000     NEKTON VERSION
+2 DIMENSIONAL RUN
+103 PARAMETERS FOLLOW
+  0.299792E+18                  1: x CSPEED The speed of light, in m/s.
+  0.885420E-20                  2: x PERMIT Vacuum permittivity (\epsilon_0)
+  0.125660E-14                  3: x PERMEA Vacuum permeability (\mu_0)
+  1                             4: x IFTE (1), IFTM (2)
+  0                             5: x IFMAXWELL=0,1,2,...;IFSCHROD=10,11,...; IFDRIFT=20,21,....,29(DG); IFDRIFT=30(w/o exciton),31(w/ exciton),39(SEM);
+  -1                            6: x source turn on(1); turn off(0); incident turn on (-1); 
+  0                             7: x inhomogeneous boundary turn on (1)
+  1                             8: x # of field (default=0)
+  0                             9: ---
+  1e20                          10: x FINTIME: Final Time
+  1000                          11: x NSTEPS: Total # of timesteps
+  -0.005                        12: x DT:  Timestep Size with (-), eg. -0.05; CFL number with (+), eg, CFL=0.2,0.3,0.4
+  10                            13: x IOCOMM : Print statement at every IOCOMM step
+  0.000000E+00                  14: x OPTIONS: number of periods (nano)
+  10                            15: x IOSTEP : Produce outputs at every IOSTEP
+  1                             16: x IFSOL: 1 (solution assgined), 0 (if not)
+  0                             17: x Timestep: 10(EIG),0 or 45(RK45),44(rk44),33(rk33),22(rk22), 1(EXP), -1(BDF1), -2(BDF2)
+  0                             18: x Filter: 0 (no filter), 1 (turn on filter), Dealias: -1 (turn on dealias)
+  0                             19: x FLUXES: 0 (upwind flux), 1 (central flux)
+  5.00000                       20: x ORDER (MESH): positive value
+  0                             21: x define poisson solver --> GMRES(1), CG(2), GMRES-SEMG(3); negative sign w/ projection GMRES(-1), CG(-2), GMRES-SEMG(-3)
+  0                             22: x tolerance      : (GMRES, CG, GMRES-SEMG)
+  0                             23: x preconditioner : FDM for CG(1)
+  0                             24: x define unsteady time dependent solver --> GMRES(1), CG(2); negative sign w/ projection GMRES(-1), CG(-2)                  
+  0                             25: x drift-diffusion GFDM (global fast diagonalization): GFDMDD (1)         
+  0                             26: ---  
+  3.00000                       27: x TORDER
+  0.000000E+00                  28: x TMESH
+  0.000000E+00                  29: ---
+  0.000000E+00                  30: ---
+  0.000000E+00                  31: ---
+  0.000000E+00                  32: ---
+  0                             33: ---
+  0                             34: ---
+  0                             35: ---
+  0                             36: ---
+  0                             37: ---
+  0.000000E+00                  38: ---
+  0.000000E+00                  39: ---
+  0.000000E+00                  40: ---
+  0.000000E+00                  41: ---
+  0.000000E+00                  42: ---
+  0                             43: ---
+  0.000000E+00                  44: ---
+  0.000000E+00                  45: ---
+  0.000000E+00                  46: ---
+  0.000000E+00                  47: ---
+  0.000000E+00                  48: ---
+  0.140000                      49: ---
+  0.000000E+00                  50: ---
+  0.000000E+00                  51: ---
+  0.000000E+00                  52: ---
+  0.000000E+00                  53: ---
+  0.000000E+00                  54: ---
+  0.000000E+00                  55: ---
+  0.000000E+00                  56: ---
+  0                             57: ---
+  0                             58: ---
+  0                             59: ---
+  0                             60: ---
+  0                             61: ---
+  0                             62: ---
+  0                             63: ---
+  0                             64: ---
+  0                             65: ---
+  0                             66: ---
+  0                             67: ---
+  0                             68: ---
+  0                             69: ---
+  0                             70: ---
+  0                             71: ---
+  0                             72: ---
+  0                             73: ---
+  0                             74: ---
+  0                             75: ---
+  0                             76: ---
+  10.0E+00                      77: x PMLTHICK : thickness of the PML in levels
+  3.0E+00                       78: x PMLORDER : polynomial order of the grading of the PML parameter sigma
+  1.0E-30                       79: x PMLREFERR : PML reflection error
+  4                             80: x I/O: total (exact) number of output fields: currently default=4
+  4                             81: x I/O: 0 (no output), 1 (fld),2 (posix ascii),3 (posix binary), 4,5, (coIO), 6,-6,8 (rbIO)
+  1                             82: x I/O: the number of outputfiles per timestep
+  0                             83: x I/O: frequency of restart output files, 0 (no restart output), #nn (iostep*nn)
+  0                             84: x RESTART (should be 0 for non-mpi run): invoked with dump_number from the name of the restarting output file
+  0                             85: x computation trace active if positive number
+  0                             86: x io trace active if positive number
+  0                             87: x I/O: "1" on BGP ;if >0, write/read restart files in float; if 0 (=default), double
+  0                             88: ---
+  0                             89: ---
+  0                             90: ---
+  0                             91: ---
+  0                             92: ---
+  0                             93: x ifdielec  0: false 1: true
+  0                             94: x ific      0: false 1: true
+  0                             95: x ifpoisson 0: false 1: true
+  0                             96: ---
+  0                             97: --- x ifarpack 0: false 1: true
+  0                             98: ---
+  0                             99: ---
+  0                             100: x 0: default, 1: ifscat, 2: ifsftf
+  0                             101: x ifdrude 0: false 1: true
+  0                             102: ---
+  0                             103: ---
+			4  Lines of passive scalar data follows2 CONDUCT; 2RHOCP
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+13 LOGICAL SWITCHES FOLLOW
+  F                             1: IFFLOW
+  T                             2: IFHEAT
+  T                             3: IFTRAN
+  F                             4: IFSRC
+  T                             5: IFCENTRAL
+  F                             6: IFUPWIND
+  F                             7: IFTM (2D only)
+  T                             8: IFTE (2D only)
+  F                             9: IFDEALIAS
+  F                             10: IFRK4
+  T                             11: IFEXP
+  F                             12: IFEIG
+  F                             13: IFNM
+  9.23077       9.23077      -4.38462      -5.30769     XFAC,YFAC,XZERO,YZERO
+ **MESH DATA** 1st line is X of corner 1,2,3,4. 2nd line is Y.
+    9     -2     9          NEL,NDIM,NELV
+2dbox.box
+            0 PRESOLVE/RESTART OPTIONS  *****
+            7         INITIAL CONDITIONS *****
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+  ***** DRIVE FORCE DATA ***** BODY FORCE, FLOW, Q
+            4                 Lines of Drive force data follow
+C                                                                               
+C                                                                               
+C                                                                               
+C                                                                               
+  ***** Variable Property Data ***** Overrrides Parameter data.
+            1 Lines follow.
+            0 PACKETS OF DATA FOLLOW
+  ***** HISTORY AND INTEGRAL DATA ***** 
+            0   POINTS.  Hcode, I,J,H,IEL
+  ***** OUTPUT FIELD SPECIFICATION *****
+            6 SPECIFICATIONS FOLLOW
+  F      COORDINATES
+  F      VELOCITY
+  F      PRESSURE
+  T      TEMPERATURE
+  F      TEMPERATURE GRADIENT
+            0      PASSIVE SCALARS
+  ***** OBJECT SPECIFICATION *****
+       0 Surface Objects 
+       0 Volume  Objects 
+       0 Edge    Objects 
+       0 Point   Objects 

--- a/tests/2dboxpml/2dboxpml.usr
+++ b/tests/2dboxpml/2dboxpml.usr
@@ -1,0 +1,386 @@
+c-----------------------------------------------------------------------
+c
+c  USER SPECIFIED ROUTINES:
+c
+c     - boundary conditions
+c     - initial conditions
+c     - variable properties
+c     - forcing function for fluid (f)
+c     - forcing function for passive scalar (q)
+c     - general purpose routine for checking errors etc.
+c
+c-----------------------------------------------------------------------
+      subroutine userinc
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'RK5'
+
+      common /userparam/ omega,eps1,eps2,mu1,mu2,refl,tran
+      real omega,eps1,eps2,mu1,mu2,refl,tran
+
+      integer i,j,k
+      real ky
+      real yy,tt,mu,eps,eta,uinc
+
+      tt = rktime
+      do i = 1,ncemincfld
+         j = cemincfld(i)
+         k = cemface(j)
+         yy = ym1(k,1,1,1)
+         eps = permittivity(k)
+         mu = permeability(k)
+         eta = sqrt(mu/eps)
+         ky = omega*sqrt(mu*eps)
+         uinc = cos(-ky*yy-omega*tt)
+         fHN(j,3) = fHN(j,3)+uinc
+         fEN(j,1) = fEN(j,1)+eta*uinc
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'PML'
+
+      real tt
+      real myhx(lx1,ly1,lz1,lelt)
+      real myhy(lx1,ly1,lz1,lelt)
+      real myhz(lx1,ly1,lz1,lelt)
+      real myex(lx1,ly1,lz1,lelt)
+      real myey(lx1,ly1,lz1,lelt)
+      real myez(lx1,ly1,lz1,lelt)
+
+      integer i
+      real mu,eps
+
+      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+c     We need to set the extra PML fields too
+      do i = 1,npts
+         mu = permeability(i)
+         eps = permittivity(i)
+         pmlbn(i,1) = mu*myhx(i,1,1,1)
+         pmlbn(i,2) = mu*myhy(i,1,1,1)
+         pmlbn(i,3) = mu*myhz(i,1,1,1)
+         pmldn(i,1) = eps*myex(i,1,1,1)
+         pmldn(i,2) = eps*myey(i,1,1,1)
+         pmldn(i,3) = eps*myez(i,1,1,1)
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'GEOMBOUND'
+      include 'PML'
+
+      common /userparam/ omega,eps1,eps2,mu1,mu2,refl,tran
+      real omega,eps1,eps2,mu1,mu2,refl,tran
+
+      real tt
+      real myshx(lx1,ly1,lz1,lelt)
+      real myshy(lx1,ly1,lz1,lelt)
+      real myshz(lx1,ly1,lz1,lelt)
+      real mysex(lx1,ly1,lz1,lelt)
+      real mysey(lx1,ly1,lz1,lelt)
+      real mysez(lx1,ly1,lz1,lelt)
+
+      integer e,i,j,l,lx1_2
+      real ky
+      real yy,mu,eps,eta,d,pmlfac,pmlsigmamax
+
+      lx1_2 = lx1/2
+      do e = 1,nelt
+         do j = 1,ly1
+            do i = 1,lx1
+c     Global number
+               l = i+nx1*(j-1)+nx1*ny1*(e-1)
+               eps = permittivity(l)
+               mu = permeability(l)
+               eta = sqrt(mu/eps)
+               ky = omega*sqrt(eps*mu)
+               yy = ym1(i,j,1,e)
+               if (ym1(lx1_2,lx1_2,1,e).gt.0.0) then
+                  if (pmltag(e).ne.0) then
+                     d = pmlouter(4)-pmlinner(4)
+                     pmlsigmamax =
+     $                    -(pmlorder+1)*log(pmlreferr)/(2*eta*d)
+                     pmlfac = (pmlsigmamax*d/(pmlorder+1))
+     $                    *((yy-pmlinner(4))/d)**(pmlorder+1)
+                  else
+                     pmlfac = 0.0
+                  endif
+                  myshz(i,j,1,e) =
+     $                 refl*exp(-eta*pmlfac)*cos(ky*yy-omega*tt)
+                  mysex(i,j,1,e) = -eta*myshz(i,j,1,e)
+               else
+                  if (pmltag(e).ne.0) then
+                     d = pmlinner(3)-pmlouter(3)
+                     pmlsigmamax =
+     $                    -(pmlorder+1)*log(pmlreferr)/(2*eta*d)
+                     pmlfac = (pmlsigmamax*d/(pmlorder+1))
+     $                    *((pmlinner(3)-yy)/d)**(pmlorder+1)
+                  else
+                     pmlfac = 0.0
+                  endif
+                  myshz(i,j,1,e) =
+     $                 tran*exp(-eta*pmlfac)*cos(-ky*yy-omega*tt)
+                  mysex(i,j,1,e) = eta*myshz(i,j,1,e)
+               endif
+            enddo
+         enddo
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(baseidx,srchx,srchy,srchz,srcex,srcey,srcez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+
+      integer baseidx
+      real srchx(lx1,ly1,lz1,lelt),
+     $     srchy(lx1,ly1,lz1,lelt),
+     $     srchz(lx1,ly1,lz1,lelt),
+     $     srcex(lx1,ly1,lz1,lelt),
+     $     srcey(lx1,ly1,lz1,lelt),
+     $     srcez(lx1,ly1,lz1,lelt)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine uservp(ix,iy,iz,iel)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+
+c     These don't do anything! This is a temporary measure until
+c
+c     https://github.com/NekCEM/NekCEM/issues/12
+c
+c     is resolved.
+      integer ix,iy,iz,iel
+
+      common /userparam/ omega,eps1,eps2,mu1,mu2,refl,tran
+      real omega,eps1,eps2,mu1,mu2,refl,tran
+
+      logical markinc
+      integer e,f,i,j,k,nx1_2
+
+      nx1_2 = nx1/2
+c     Set the permittivity and permeability
+      do e = 1,nelt
+         do i = 1,nxyz
+            j = i+nx1*ny1*nz1*(e-1)
+            if (ym1(nx1_2,nx1_2,nx1_2,e).gt.0) then
+c     Upper region
+               permittivity(j) = eps1
+               permeability(j) = mu1
+            else
+c     Lower region
+               permittivity(j) = eps2
+               permeability(j) = mu2
+            endif
+         enddo
+      enddo
+
+c     Mark the faces where the incident field needs to be added
+      do e = 1,nelt
+         if (ym1(nx1_2,nx1_2,1,e).gt.0.0) then
+            markinc = .true.
+            do f = 1,nfaces
+               do i = 1,nxzf
+c     j is the global face number
+                  j = (e-1)*nxzf*nfaces+nxzf*(f-1)+i
+c     k is the volume global number associated with face j.
+                  k = cemface(j)
+                  write(*,*) 'aaa',k
+                  if (abs(ym1(k,1,1,1)).gt.1e-8) then
+                     markinc = .false.
+                     exit
+                  endif
+               enddo
+               if (markinc) then
+                  do i = 1,nxzf
+                     j = (e-1)*nxzf*nfaces+nxzf*(f-1)+i
+                     fincmarker(j) = 1
+                  enddo
+               endif
+            enddo
+         endif
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userq(ix,iy,iz,ieg)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE'
+
+      qvol = 0.0
+      source = 0.0
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine useric(ix,iy,iz,ieg)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE'
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userbc(ix,iy,iz,iside,ieg)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE'
+
+      ux = 0.0
+      uy = 0.0
+      uz = 0.0
+      temp = 0.0
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+
+      common /userparam/
+     $     omega,               ! frequency of the incident wave
+     $     eps1,                ! permittivity in upper region
+     $     eps2,                ! permittivity in lower region
+     $     mu1,                 ! permeability in upper region
+     $     mu2,                 ! permeability in lower region
+     $     refl,                ! reflection coefficient
+     $     tran                 ! transmission coefficient
+
+      real omega,eps1,eps2,mu1,mu2,refl,tran
+
+      omega = 5.0
+      eps1 = 1.0
+      eps2 = 1.0
+      mu1 = 1.0
+      mu2 = 1.0
+
+      z1 = sqrt(mu1/eps1)
+      z2 = sqrt(mu2/eps2)
+      refl = (z1-z2)/(z1+z2)
+      tran = 2*z1/(z1+z2)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat2
+c-----------------------------------------------------------------------
+c     Use this subroutine to set the dimensions of the domain.
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'GEOMBOUND'
+
+      integer e,f,i,j,n,nxy2
+      real glmin,glmax
+      real sx,sy,sz,xmid,ymid,zmid
+
+      n = nx1*ny1*nz1*nelv
+
+      xmin = glmin(xm1,n)
+      xmax = glmax(xm1,n)
+      ymin = glmin(ym1,n)
+      ymax = glmax(ym1,n)
+      zmin = glmin(zm1,n)
+      zmax = glmax(zm1,n)
+
+      sx = 5.0
+      sy = 10.0
+      if (if3d) sz = 5.0
+
+      do i = 1,n
+         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)/(xmax-xmin)-(sx/2.0)
+         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)/(ymax-ymin)-(sy/2.0)
+         if (if3d) then
+            zm1(i,1,1,1) = sz*(zm1(i,1,1,1)-zmin)/(zmax-zmin)-(sz/2.0)
+         endif
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userft
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userchk
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+      real l2htol(3),l2etol(3)
+      real linfhtol(3),linfetol(3)
+
+      l2htol(1) = 0.0
+      l2htol(2) = 0.0
+      l2htol(3) = 5e-8
+      l2etol(1) = 5e-8
+      l2etol(2) = 5e-8
+      l2etol(3) = 0.0
+
+      linfhtol(1) = 0.0
+      linfhtol(2) = 0.0
+      linfhtol(3) = 1e-6
+      linfetol(1) = 1e-6
+      linfetol(2) = 1e-6
+      linfetol(3) = 0.0
+
+      if (istep.le.10.or.mod(istep,iocomm).eq.0) then
+         call usersol(time,shn(1,1),shn(1,2),shn(1,3),sen(1,1),sen(1,2)
+     $        ,sen(1,3))
+
+         call cem_errorchk(hn,shn,errhn,l2htol,linfhtol)
+         call cem_errorchk(en,sen,erren,l2etol,linfetol)
+      endif
+
+      return
+      end
+c-----------------------------------------------------------------------

--- a/tests/2dboxpml/SIZEu
+++ b/tests/2dboxpml/SIZEu
@@ -1,0 +1,181 @@
+c     Dimension file to be included
+c
+c     HCUBE array dimensions
+      integer ldim,lxi,lx1,ly1,lz1,lelv,lelt,lp,lelg
+      integer lxs,lys,lzs,lgmres,lfdm
+      parameter (ldim = 2)
+      parameter (lxi = 8)  ! polynomial order
+      parameter (lx1 = lxi+1,ly1 = lxi+1,lz1 = 1+lxi*(ldim-2))
+      parameter (lelv = 32, lelt = lelv)
+      parameter (lp = 4)
+      parameter (lelg = lp*lelt)
+      parameter (lxs = 1,lys = lxs,lzs = (lxs-1)*(ldim-2)+1)
+      parameter (lgmres = 1)
+      parameter (lfdm = 0)  !global fast diagonalization method (1=on; 0=off)
+
+c     Choose meshes: if mesh=0 (hex/quad), if mesh=1 (tet/tri)
+c     Build  basis : DG (default), if nedelec=1 (nedelec)
+      integer mesh,nedelec
+      parameter (mesh    = 0)
+      parameter (nedelec = 0)
+
+c     Arrays for new GEOM in TMPINPUT: temporary
+      integer    lpts,lxzfl,lxyzm
+      parameter (lpts = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl= lx1*lz1*2*ldim*lelt)
+      parameter (lxyzm= lx1*ly1*lz1        )
+
+c     Assign different size for different solvers
+      integer    lpts1,lxzfl1,lpts2,lxzfl2,lpts3,lxzfl3,lpts4,lxzfl4
+      integer    lpts5,lxzfl5,lfp,lxd,lyd,lzd
+      integer    lpts10,lxzfl10
+
+c     Arrays for Maxwell solver
+      parameter (lpts1 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl1= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Drude/Lorentz/Hydraulic Models with Maxwell
+      parameter (lpts10 = lpts1 )
+      parameter (lxzfl10= lxzfl1)
+
+c     Arrays for Schrodinger solver
+      parameter (lpts2 = 1) !(lpts2= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl2= 1) !(lxzfl2= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Acoustic solver
+      parameter (lpts3 = 1) !(lpts3= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl3= 1) !(lxzfl3= lx1*lz1*2*ldim*lelt)
+      parameter (lfp   = 1) ! fourier points for DtN operator
+
+c     Arrays for Drift-Diffusion solver
+      parameter (lpts4 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl4= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Nedelec solver
+      parameter (lxd   =lx1,lyd=ly1,lzd=lz1)
+      parameter (lpts5 =1)! lxd*lyd*lzd*lelt   )
+      parameter (lxzfl5=1)! lxd*lzd*2*ldim*lelt)
+
+c     Arrays for Eigenvalue calculations: when not using set it as 1
+      integer    lpts_eig
+      parameter (lpts_eig = 1)
+c     parameter (lpts_eig = lx1*ly1*lz1*lelt*2*ldim)
+
+c     Arrays for Quantum Model calculations
+      integer    level,lnumqd,lnumsp,lstate,lrho,leqn,lEh
+      parameter (level   = 1      )       ! number of qd states
+      parameter (lnumqd  = 1      )       ! number of surface plasmon states
+      parameter (lnumsp  = 1      )       ! number of surface plasmon states
+      parameter (lstate  = level**lnumqd*lnumsp)   ! number of total states
+      parameter (lrho    = lstate*lstate) ! number of rho
+      parameter (leqn    = 1      )       ! number of eqns: real/imag
+      parameter (lEh     = 1      )       ! number of energy
+
+c     Exponential Integrator
+      integer    larnol,luniform,levg,lelg2d,lmov,lw
+      parameter (larnol  = 1)
+      parameter (luniform= 1)
+      parameter (levg    = 1)
+      parameter (lelg2d  = 9)
+      parameter (lmov    = 0)
+      parameter (lw      = 5)
+
+c     Interpolation: lpart = the number of points for interpolation
+      integer    lpart
+      parameter (lpart= 1)
+
+c     Arrays for .box mesh
+      integer    lelx , lely , lelz
+      integer    lpelv, lpelt, lpert
+      integer    lpx1 , lpy1 , lpz1
+      integer    lpx2 , lpy2 , lpz2
+      integer    lbelt, lbelv
+      integer    lbx1 , lby1 , lbz1
+      integer    lbx2 , lby2 , lbz2
+      parameter (lelx =32,lely =32 ,lelz =lelx )
+      parameter (lpelv=1,lpelt=lpelv,lpert=lpelv)
+      parameter (lpx1 =1,lpy1 =lpx1 ,lpz1 =lpx1 )
+      parameter (lpx2 =1,lpy2 =lpx2 ,lpz2 =lpx2 )
+      parameter (lbelv=lelv, lbelt=lelv )
+      parameter (lbx1 =1,lby1 =lbx1 ,lbz1 =lbx1 )
+      parameter (lbx2 =1,lby2 =lbx2 ,lbz2 =lbx2 )
+
+      integer    lzl
+      integer    lx2, ly2, lz2
+      integer    lx3, ly3, lz3
+      integer    lx1m, ly1m, lz1m
+      integer    ldimt, ldimt1, ldimt3
+
+      PARAMETER (LZL=1+2*(ldim-2))
+      PARAMETER (LX2=LX1)
+      PARAMETER (LY2=LY1)
+      PARAMETER (LZ2=LZ1-2*(ldim-2))
+      PARAMETER (LX3=LX1)
+      PARAMETER (LY3=LY1)
+      PARAMETER (LZ3=LZ1)
+
+C     LX1M=LX1 when there are moving meshes; =1 otherwise
+      PARAMETER (LX1M  =1,LY1M=1,LZ1M=1)
+      PARAMETER (LDIMT = 1)
+      PARAMETER (LDIMT1=LDIMT+1)
+      PARAMETER (LDIMT3=LDIMT+3)
+
+c
+c     Note:  In the new code, LELGEC should be about sqrt(LELG)
+c
+      integer    lelgec, lxyz2, lxz21
+      PARAMETER (LELGEC = 1)
+      PARAMETER (LXYZ2  = 1)
+      PARAMETER (LXZ21  = 1)
+c
+c     integer    lmaxv, lmaxt, lmaxp
+      integer    lxz, lorder, maxobj, maxmbr
+c     PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
+c     PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
+c     PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
+      PARAMETER (LXZ=LX1*LZ1)
+      PARAMETER (LORDER=3)
+      PARAMETER (MAXOBJ=2,MAXMBR=LELT*6)
+C
+C     Common Block Dimensions
+C
+      integer    lctmp0, lctmp1
+      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
+      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
+C
+C     The parameter LVEC controls whether an additional 42 field arrays
+C     are required for Steady State Solutions.  If you are not using
+C     Steady State, it is recommended that LVEC=1.
+C
+      integer    lvec
+      PARAMETER (LVEC=1)
+C
+C     Uzawa projection array dimensions
+C
+c     PARAMETER (MXPREV = 01)
+C
+C     Split projection array dimensions
+C
+      integer    lmvec, lsvec, lstore
+      parameter (lmvec = 1)
+      parameter (lsvec = 1)
+      parameter (lstore=lmvec*lsvec)
+c
+c     NONCONFORMING STUFF
+c
+      integer    maxmor
+      parameter (maxmor = lelt)
+C
+C     Array dimensions
+C
+      integer    nelv, nelt
+      integer    nx1, ny1, nz1
+      integer    nx2, ny2, nz2
+      integer    nx3, ny3, nz3
+      integer    ndim, nfield, nid, npert
+      integer    nxyz, npts, nxzf, nxzfl, nfaces
+
+      COMMON /DIMN/
+     $           NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
+     $          ,NX3,NY3,NZ3,NDIM,NFIELD,NID,NPERT
+     $          ,NXYZ,NPTS,NXZF,NXZFL,NFACES

--- a/tests/test_nekcem.py
+++ b/tests/test_nekcem.py
@@ -11,7 +11,7 @@ arch = pytest.config.getoption('arch')
 np = pytest.config.getoption('np')
 rebuild = pytest.config.getoption('rebuild')
 
-names = ['2dboxper', '2dboxpec']
+names = ['2dboxper', '2dboxpec', '2dboxpml']
 testdata = [(name, build_command, arch, np, rebuild) for name in names]
 
 if os.path.isfile(LOGFILE):


### PR DESCRIPTION
This tests a normal-incidence plane wave hitting a PML region. In adding the test I ran into the issues from https://github.com/NekCEM/NekCEM/issues/12, so this also begins resolving that issue for the Maxwell case by not calling `uservp` in a loop. The `2dboxper` and `2dboxpec` tests are updated accordingly.

@misunmin you should take a look since this contains larger structural changes.