### PR TITLE
Use CFL number in `2dboxpml` instead of a fixed timestep

### DIFF
--- a/tests/2dboxpml/2dboxpml.rea
+++ b/tests/2dboxpml/2dboxpml.rea
@@ -13,7 +13,7 @@
   0                             9: ---
   1e20                          10: x FINTIME: Final Time
   4000                          11: x NSTEPS: Total # of timesteps
-  -0.003                        12: x DT:  Timestep Size with (-), eg. -0.05; CFL number with (+), eg, CFL=0.2,0.3,0.4
+  0.1                           12: x DT:  Timestep Size with (-), eg. -0.05; CFL number with (+), eg, CFL=0.2,0.3,0.4
   10                            13: x IOCOMM : Print statement at every IOCOMM step
   0.000000E+00                  14: x OPTIONS: number of periods (nano)
   10                            15: x IOSTEP : Produce outputs at every IOSTEP


### PR DESCRIPTION
Previously the two tests required slightly different fixed timesteps
(`0.005` for TE versus `0.003` for TM), so it is more satisfying that
both work correctly using the CFL condition.