### PR TITLE
Run `pytest` in verbose mode on Travis

### DIFF
--- a/bin/travis.sh
+++ b/bin/travis.sh
@@ -4,7 +4,7 @@ WHITELIST="drive.F maxwell.F utilities.F"
 
 
 if [[ $TESTS == 1 ]]; then
-    pytest --np 2
+    pytest -v --np 2
     if [[ $? != 0 ]]; then
 	cat tests/build.log
 	exit 1


### PR DESCRIPTION
This way we can see how many tests have run without counting little
dots.