### PR TITLE
Add `drift2d`/`drift3d` tests/Allow arbitrary `.usr` files

### DIFF
--- a/bin/Makefile.inc
+++ b/bin/Makefile.inc
@@ -6,6 +6,7 @@
 ?LDFLAGS?
 ?NEKBASE?
 ?JLBASE?
+?USR?
 
 FSRC = $(shell find $(NEKBASE) -name *.F | grep -v 'nek5_comm' \
 					 | grep -v 'mxm')
@@ -25,7 +26,6 @@ poly.c lob_bnd.c findpts_el_3.c findpts_el_2.c sparse_cholesky.c	\
 xxt.c fcrs.c sort.c
 JLSRC = $(patsubst %, $(JLBASE)/%, $(JLFILES))
 JLOBJ = $(patsubst $(JLBASE)/%.c, obj/%.o, $(JLSRC))
-USR = $(wildcard *.usr)
 USROBJ = obj/subuser.o
 
 

--- a/bin/configurenek
+++ b/bin/configurenek
@@ -85,7 +85,7 @@ def get_cflags(CC):
     return CFLAGS
 
 
-def write_makefile(JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
+def write_makefile(usr, JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
     NEKBASE = os.path.join(NEK, 'src')
     nekfn = os.path.join(NEK, 'bin', 'Makefile.inc')
     fn = os.path.join(EXAMPLE, 'Makefile')
@@ -104,11 +104,13 @@ def write_makefile(JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
                 line = line.replace('?NEKBASE?',
                                     'NEKBASE = {0}'.format(NEKBASE))
                 line = line.replace('?JLBASE?', 'JLBASE = {0}'.format(JL))
+                line = line.replace('?USR?', 'USR = {0}'.format(usr))
                 make.write(line)
 
 
 def main():
     parser = argparse.ArgumentParser(description='Build a makefile')
+    parser.add_argument('usr', help='Which usr file to use')
     parser.add_argument('--arch', help='Use a predefined architecture')
     parser.add_argument('--jl', help='Specify path to the jl library')
     parser.add_argument('--FC', help='Fortran compiler to use')
@@ -123,6 +125,7 @@ def main():
     parser.add_argument('--LDFLAGS', help='Linker flags')
     parser.add_argument('--extra-LDFLAGS', help='Extra linker flags')
     args = parser.parse_args()
+    usr = args.usr + '.usr'
     if args.arch:
         if args.FC or args.FFLAGS or args.CC or args.CFLAGS:
             raise ValueError("can't set arch and compilers/flags")
@@ -165,7 +168,7 @@ def main():
         JL = args.jl
     else:
         JL = os.path.join(NEK, 'src', 'jl')
-    write_makefile(JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS)
+    write_makefile(usr, JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS)
 
 
 if __name__ == '__main__':

--- a/bin/makenek
+++ b/bin/makenek
@@ -5,7 +5,7 @@
 
 # Installation path. Default is one directory up from the location of
 # this script.
-NEK="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+NEK="../.."
 
 # Specify the compilers, linker, and flags. There are three ways to do this.
 #
@@ -55,8 +55,14 @@ JLSRC="$NEK/src/jl"
 
 set -e
 
+if [ $# != 1 ]; then
+    echo "Please provide exactly one .usr file as an argument" 1>&2
+    exit 1
+fi
+USR=$1
+
 # Create makefile
-$NEK/bin/configurenek --FC "$FC" --FFLAGS "$FFLAGS" \
+$NEK/bin/configurenek "$USR" --FC "$FC" --FFLAGS "$FFLAGS" \
 		      --extra-FFLAGS "$EXTRAFFLAGS" \
 		      --CC "$CC" --CFLAGS "$CFLAGS" \
 		      --extra-CFLAGS "$EXTRACFLAGS" \

--- a/src/cem_drift.F
+++ b/src/cem_drift.F
@@ -5556,7 +5556,7 @@ c     if (lx1.eq.6)  mgnx2 = 3
       if (nid.eq.0) write(*,*) 'h1_mg_ny:',(mg_ny(i),i=1,mg_h1_lmax)
       if (nid.eq.0) write(*,*) 'h1_mg_nz:',(mg_nz(i),i=1,mg_h1_lmax)
 
-      if (nid.eq.0) write(6,*) 'dddddd',ldimt1
+      if (nid.eq.0) write(6,*) 'ldimt1',ldimt1
       do ifld=1,ldimt1
       do l=1,mg_lmax
          mg_h1_n(l,ifld)=(mg_nx(l)+1)

--- a/tests/drift2d/2dboxpecp.box
+++ b/tests/drift2d/2dboxpecp.box
@@ -1,0 +1,16 @@
+2dboxpecp.rea     
+2
+3                      number of fields
+#
+#    comments
+#
+#
+#========================================================
+#
+Box
+-8  -8  (number of elements in x,y)
+-1  1   1              (x0,x1,gain)
+-1  1   1              (x0,x1,gain)
+PEC,PEC,P  ,P                                (bc's)
+PEC,PEC,P  ,P                                (bc's)
+PEC,PEC,P  ,P                                (bc's)

--- a/tests/drift2d/2dboxpecp.rea
+++ b/tests/drift2d/2dboxpecp.rea
@@ -1,0 +1,178 @@
+  ****** PARAMETERS *****
+    2.610000     NEKTON VERSION
+2 DIMENSIONAL RUN
+118 PARAMETERS FOLLOW
+  0                             1: ---  
+  0                             2: ---
+  0                             3: ---
+  1                             4: x IFTE (1), IFTM (2)
+  30                            5: x IFMAXWELL=0,1,2,...;IFSCHROD=10,11,...; IFDRIFT=20,21,....,29(DG); IFDRIFT=30(w/o exciton),31(w/ exciton),39(SEM);
+  1                             6: x source turn on(1); turn off(0); incident turn on (-1);
+  0                             7: x inhomogeneous boundary turn on (1)
+  3                             8: x # of field (default=0)
+  0                             9: ---
+  1e20                          10: x FINTIME: Final Time
+  100                           11: x NSTEPS: Total # of timesteps
+  -0.000001                     12: x DT:  Timestep Size with (-), eg. -0.05; CFL number with (+), eg, CFL=0.2,0.3,0.4
+  10                            13: x IOCOMM : Print statement at every IOCOMM step
+  0.000000E+00                  14: x OPTIONS: number of periods (nano)
+  10                            15: x IOSTEP : Produce outputs at every IOSTEP
+  1                             16: x IFSOL: 1 (solution assgined), 0 (if not)
+  -1                            17: x Timestep: 10(EIG),0 or 45(RK45),44(rk44),33(rk33),22(rk22), 1(EXP), -1(BDF1), -2(BDF2)
+  0                             18: x Filter: 0 (no filter), 1 (turn on filter), Dealias: -1 (turn on dealias)
+  0                             19: x FLUXES: 0 (upwind flux), 1 (central flux)
+  5.00000                       20: x ORDER (MESH): positive value
+  2                             21: x define poisson solver --> GMRES(1), CG(2), GMRES-SEMG(3); negative sign w/ projection GMRES(-1), CG(-2), GMRES-SEMG(-3)
+  1.E-12                        22: x tolerance      : (GMRES, CG, GMRES-SEMG)
+  1                             23: x preconditioner : FDM for CG(1)
+  2                           24: x define unsteady time dependent solver --> GMRES(1), CG(2); negative sign w/ projection GMRES(-1), CG(-2)
+  0                             25: x drift-diffusion GFDM (global fast diagonalization): GFDMDD (1)
+  0                             26: ---
+  3.00000                       27: x TORDER
+  0.000000E+00                  28: x TMESH
+  0.000000E+00                  29: ---
+  0.000000E+00                  30: ---
+  0.000000E+00                  31: ---
+  0.000000E+00                  32: ---
+  0                             33: ---
+  0                             34: ---
+  0                             35: ---
+  0                             36: ---
+  0                             37: ---
+  0.000000E+00                  38: ---
+  0.000000E+00                  39: ---
+  0.000000E+00                  40: ---
+  0.000000E+00                  41: ---
+  0.000000E+00                  42: ---
+  0                             43: ---
+  0.000000E+00                  44: ---
+  0.000000E+00                  45: ---
+  0.000000E+00                  46: ---
+  0.000000E+00                  47: ---
+  0.000000E+00                  48: ---
+  0.140000                      49: ---
+  0.000000E+00                  50: ---
+  0.000000E+00                  51: ---
+  0.000000E+00                  52: ---
+  0.000000E+00                  53: ---
+  0.000000E+00                  54: ---
+  0.000000E+00                  55: ---
+  0.000000E+00                  56: ---
+  0                             57: ---
+  0                             58: ---
+  0                             59: ---
+  0                             60: ---
+  0                             61: ---
+  0                             62: ---
+  0                             63: ---
+  0                             64: ---
+  0                             65: ---
+  0                             66: ---
+  0                             67: ---
+  0                             68: ---
+  0                             69: ---
+  0                             70: ---
+  0                             71: ---
+  0                             72: ---
+  0                             73: ---
+  0                             74: ---
+  0                             75: ---
+  0                             76: ---
+  1.000000E+00                  77: x PMLTHICK : thickness of the PML in levels
+  2.000000E+00                  78: x PMLORDER : polynomial order of the grading of the PML parameter sigma
+  1.000000E-05                  79: x PMLREFERR : PML reflection error
+  4                             80: x I/O: total (exact) number of output fields: currently default=4
+  0                             81: x I/O: 0 (no output), 1 (fld),2 (posix ascii),3 (posix binary), 4,5, (coIO), 6,-6,8 (rbIO)
+  1                             82: x I/O: the number of outputfiles per timestep
+  0                             83: x I/O: frequency of restart output files, 0 (no restart output), #nn (iostep*nn)
+  0                             84: x RESTART (should be 0 for non-mpi run): invoked with dump_number from the name of the restarting output file
+  0                             85: x computation trace active if positive number
+  0                             86: x io trace active if positive number
+  0                             87: x I/O: "1" on BGP ;if >0, write/read restart files in float; if 0 (=default), double
+  0                             88: ---
+  0                             89: ---
+  0                             90: ---
+  0                             91: ---
+  0                             92: ---
+  0                             93: x ifdielec  0: false 1: true
+  0                             94: x ific      0: false 1: true
+  0                             95: x ifpoisson 0: false 1: true
+  0                             96: ---
+  0                             97: x ifarpack 0: false 1: true
+  0                             98: ---
+  0                             99: ---
+  0                             100: x 0: default, 1: ifscat, 2: ifsftf
+  0                             101: x ifdrude 0: false 1: true
+  0                             102: ---
+  0                             103: ---
+  0                             104: ???
+  0                             105: ???
+  0                             106: ???
+  0                             107: ???
+  0                             108: ???
+  0                             109: ???
+  0                             110: ???
+  0                             111: ???
+  0                             112: ???
+  0                             113: ???
+  0                             114: ???
+  0                             115: ???
+  8                             116: ???
+  8                             117: ???
+  1                             118: ???
+			4  Lines of passive scalar data follows2 CONDUCT; 2RHOCP
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+13 LOGICAL SWITCHES FOLLOW
+  F                             1: IFFLOW
+  T                             2: IFHEAT
+  T                             3: IFTRAN
+  F                             4: IFSRC
+  T                             5: IFCENTRAL
+  F                             6: IFUPWIND
+  F                             7: IFTM (2D only)
+  T                             8: IFTE (2D only)
+  F                             9: IFDEALIAS
+  F                             10: IFRK4
+  T                             11: IFEXP
+  F                             12: IFEIG
+  F                             13: IFNM
+  9.23077       9.23077      -4.38462      -5.30769     XFAC,YFAC,XZERO,YZERO
+ **MESH DATA** 1st line is X of corner 1,2,3,4. 2nd line is Y.
+    16    -2    16          NEL,NDIM,NELV
+2dboxpecp.box
+            0 PRESOLVE/RESTART OPTIONS  *****
+            7         INITIAL CONDITIONS *****
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+  ***** DRIVE FORCE DATA ***** BODY FORCE, FLOW, Q
+            4                 Lines of Drive force data follow
+C                                                                               
+C                                                                               
+C                                                                               
+C                                                                               
+  ***** Variable Property Data ***** Overrrides Parameter data.
+            1 Lines follow.
+            0 PACKETS OF DATA FOLLOW
+  ***** HISTORY AND INTEGRAL DATA ***** 
+            0   POINTS.  Hcode, I,J,H,IEL
+  ***** OUTPUT FIELD SPECIFICATION *****
+            6 SPECIFICATIONS FOLLOW
+  F      COORDINATES
+  F      VELOCITY
+  F      PRESSURE
+  T      TEMPERATURE
+  F      TEMPERATURE GRADIENT
+            0      PASSIVE SCALARS
+  ***** OBJECT SPECIFICATION *****
+       0 Surface Objects 
+       0 Volume  Objects 
+       0 Edge    Objects 
+       0 Point   Objects 

--- a/tests/drift2d/2dboxpecp.usr
+++ b/tests/drift2d/2dboxpecp.usr
@@ -1,0 +1,405 @@
+c-----------------------------------------------------------------------
+c
+c  USER SPECIFIED ROUTINES:
+c
+c     - boundary conditions
+c     - initial conditions
+c     - variable properties
+c     - forcing function for fluid (f)
+c     - forcing function for passive scalar (q)
+c     - general purpose routine for checking errors etc.
+c
+c-----------------------------------------------------------------------
+      subroutine userinc
+c-----------------------------------------------------------------------
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'DRIFT'  
+      include 'NEKUSE'
+      include 'POISSON'  
+      
+      real tt
+      real myhx(lx1*ly1*lz1*lelt)
+      real myhy(lx1*ly1*lz1*lelt)
+      real myhz(lx1*ly1*lz1*lelt)
+      real myex(lx1*ly1*lz1*lelt)
+      real myey(lx1*ly1*lz1*lelt)
+      real myez(lx1*ly1*lz1*lelt)
+
+      tt=1.0
+ 
+      do ie=1,nelt
+        do i= 1,nxyz
+          j = (ie-1)*nxyz+i
+          xx = xm1(i,1,1,ie)
+          yy = ym1(i,1,1,ie)
+          tmp = (sin(pi*xx)*sin(tt))**2
+          cN(j)= tmp      ! cN or potent
+          cP(j)= tmp*2.0  ! cP
+          cE(j)= 0.0      ! cE
+        enddo
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'DRIFT'
+      include 'NEKUSE'
+      include 'GEOMBOUND'
+
+      real tt
+      real myshx(lx1*ly1*lz1*lelt)
+      real myshy(lx1*ly1*lz1*lelt)
+      real myshz(lx1*ly1*lz1*lelt)
+      real mysex(lx1*ly1*lz1*lelt)
+      real mysey(lx1*ly1*lz1*lelt)
+      real mysez(lx1*ly1*lz1*lelt)
+
+      real xx,yy,zz,tmp  
+      integer i,j,ie                          
+     
+      do ie=1,nelt 
+        do i= 1,nxyz
+          j = (ie-1)*nxyz+i
+          xx =  xm1(i,1,1,ie)
+          yy =  ym1(i,1,1,ie)
+          tmp = (sin(pi*xx)*sin(tt))**2
+          myshx(j)= tmp      ! cN or potent 
+          myshy(j)= tmp*2.0  ! cP
+          myshz(j)= 0.0      ! cE 
+          mysex(j)= 0.0      ! dummy
+          mysey(j)= 0.0      ! dummy
+          mysez(j)= 0.0      ! dummy
+        enddo
+      enddo 
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc
+     $            (baseidx,rhs_cn,rhs_cp,rhs_ce,rhs_phi,dumm1,dumm2)     
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'DRIFT'
+      include 'POISSON'
+      include 'RK5'
+      include 'BCS'
+      integer i,j,i0,baseidx
+      real    xx,yy,tt,pi2 
+      real    sinx,cosx2,sinx2,sint2,dudx,dudy,uu
+      real    tmp1,tmp2,tmp3,tmp4    
+      real    rhs_cn(1),rhs_cp(1),rhs_ce(1),rhs_phi(1)
+      real    nbc_cn(lx1*ly1*lz1*lelt)
+      real    nbc_cp(lx1*ly1*lz1*lelt)
+      real    nbc_ce(lx1*ly1*lz1*lelt)
+      real    nbc_phi(lx1*ly1*lz1*lelt)
+
+      real    dumm1(1),dumm2(1)
+      real    unx0,uny0,unz0,area0
+
+c.....source for c_n,c_p,c_e at current step: time= istep*dt = time+dt
+      if (ifrk) then
+         tt=rktime
+      else
+         tt=time+dt 
+      endif
+      pi2 = pi*pi
+      do i=1,npts
+         xx    = xm1(i,1,1,1)
+         yy    = ym1(i,1,1,1)
+         sint2 = sin(tt)**2  
+         sinx  = sin(    pi*xx)
+         sinx2 = sin(2.0*pi*xx)
+         cosx2 = cos(2.0*pi*xx)
+         uu    = (sinx**2)*sint2               
+         dudx  = pi*sinx2 *sint2      
+         dudy  = 0.d0
+
+         tmp1  =  sin(2.0*tt)*sinx**2      ! dudt
+         tmp2  = -2.*pi2*sin(tt)**2*cosx2  !-laplace(u)  
+         tmp3  = (dudx**2+dudy**2)         ! grad(phi)*grad(u)
+         tmp4  = uu*(-tmp2)                ! u*laplace(phi)
+
+         rhs_cn(i)=  tmp1+tmp2+tmp3+tmp4
+         rhs_cp(i)= (tmp1+tmp2-tmp3-tmp4)*2.0
+         rhs_ce(i)=  0.0             
+      enddo
+      call col2(rhs_cN,bmn,npts)
+      call col2(rhs_cP,bmn,npts)
+
+c.....source for Neumann boundary value at time 
+      if (ifrk) then
+         tt=rktime
+      else
+         tt=time+dt 
+      endif
+      call rzero(nbc_cn,npts)
+      call rzero(nbc_cp,npts)
+      do i=1,ncemface_nmn(1)
+         j     = cemface_nmn(i,1)
+         i0    = cemface(j)
+         xx    = xm1(i0,1,1,1)
+         yy    = ym1(i0,1,1,1)
+         unx0  = unxm(j)
+         uny0  = unym(j)
+         area0 = aream(j)
+         sint2 = sin(tt)**2  
+         sinx  = sin(    pi*xx)
+         sinx2 = sin(2.0*pi*xx)
+         cosx2 = cos(2.0*pi*xx)
+         uu    = (sinx**2)*sint2           ! u
+         dudx  = pi*sinx2 *sint2      
+         dudy  = 0.d0
+         tmp1  =unx0*dudx+uny0*dudy
+         nbc_cn(i0)=tmp1*area0
+         tmp2  =(unx0*dudx+uny0*dudy)*2.0
+         nbc_cp(i0)=tmp2*area0
+      enddo 
+      call add2s2(rhs_cn,nbc_cn,1.0,npts)
+      call add2s2(rhs_cp,nbc_cp,1.0,npts)
+
+c.....source for potential field (phi) at time
+      tt= time
+      do i=1,npts
+         xx   = xm1(i,1,1,1)
+         yy   = ym1(i,1,1,1)
+
+         sint2 = sin(tt)**2  
+         cosx2 = cos(2.0*pi*xx)
+         sinx  = sin(    pi*xx)
+
+         tmp1 = sinx**2*sint2       ! u
+         tmp2 =-2.0*pi**2*sint2*cosx2
+         tmp3 = tmp2-charge(i)*tmp1
+         rhs_phi(i) = charge(i)*(cP(i)-cN(i))
+         rhs_phi(i) = rhs_phi(i)+tmp3
+      enddo
+      call col2(rhs_phi,bmn,npts)
+
+c.....source for potential field (phi) with Neumann boundary value at time 
+      tt= time
+      call rzero(nbc_phi,npts)
+      do i=1,ncemface_nmn(1)
+         j     = cemface_nmn(i,1)
+         i0    = cemface(j)
+         xx    = xm1(i0,1,1,1)
+         yy    = ym1(i0,1,1,1)
+         unx0  = unxm(j)
+         uny0  = unym(j)
+         area0 = aream(j)
+         sint2 = sin(tt)**2  
+         sinx  = sin(    pi*xx)
+         sinx2 = sin(2.0*pi*xx)
+         cosx2 = cos(2.0*pi*xx)
+         uu    = (sinx**2)*sint2           ! u
+         dudx  = pi*sinx2 *sint2      
+         dudy  = 0.d0
+         tmp1  =unx0*dudx+uny0*dudy
+         nbc_phi(i0)=tmp1*area0
+      enddo 
+      call add2s2(rhs_phi,nbc_phi,1.0,npts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine uservp (ix,iy,iz,iel)
+c--------------------------------------------------------------------- 
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE' 
+      include 'EMWAVE' 
+      include 'DRIFT'
+      include 'POISSON'
+      integer  i,j,k,l,ie,ieg
+      real     tmp
+
+      if (ifsol) then
+
+          K_beta      = 1.0
+          temperature = 1.0
+          tau_n       = 1
+          tau_p       = 1
+
+          call rone(d_permit,npts)
+          call rone(d_permea,npts)
+
+      else
+         if (nid.eq.0) write(6,*) 'this is exact solution case'
+         call exitt
+      endif
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat2
+
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'GEOMBOUND'
+      real     rscale
+
+      n = nx1*ny1*nz1*nelt
+
+      xmin = glmin(xm1,n)
+      xmax = glmax(xm1,n)
+      ymin = glmin(ym1,n)
+      ymax = glmax(ym1,n)
+      zmin = glmin(zm1,n)
+      zmax = glmax(zm1,n)
+
+      rscale =0.02 
+      sx = 100.0*rscale/(xmax-xmin)
+      sy = 100.0*rscale/(ymax-ymin)       
+      if (nid.eq.0) write(6,*) 'sx/sy',sx,sy,rscale
+  
+      do i=1,n
+         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0               
+         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0                        
+      enddo
+
+      xmin = glmin(xm1,n)
+      xmax = glmax(xm1,n)
+      ymin = glmin(ym1,n)
+      ymax = glmax(ym1,n)
+
+      if (nid.eq.0) write(6,*) 'xmin/xmax', xmin,xmax
+      if (nid.eq.0) write(6,*) 'ymin/ymax', xmin,xmax
+      mx = nx1/2
+      my = ny1/2
+      mz = 1
+      do ie=1,nelt
+
+         xxmax = vlmax(xm1(1,1,1,ie),nxyz)
+         xxmin = vlmin(xm1(1,1,1,ie),nxyz)
+         yymax = vlmax(ym1(1,1,1,ie),nxyz)
+         yymin = vlmin(ym1(1,1,1,ie),nxyz)
+
+         xxmid = xm1(mx,my,mz,ie)
+         yymid = ym1(mx,my,mz,ie)
+
+         if (yymid.gt. 0) then
+             if_in_region(ie) =  1
+         else
+             if_in_region(ie) = -1
+         endif
+
+      enddo
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userchk
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'DRIFT' 
+      include 'POISSON'
+
+      common /ccpu/ cpu_t,cpu_dtime,cpu_chk
+      real cpu_t,cpu_dtime,cpu_chk
+      
+      integer i
+      real l2(6),linf(6)
+      real l2tol(6),linftol(6)
+      real cpu_p_t
+      real dummy(lx1*ly1*lz1*lelt)
+
+
+      l2(1) = 0.0  
+      l2(2) = 0.0  
+      l2(3) = 0.0
+      l2(4) = 0.0   
+      l2(5) = 0.0
+      l2(6) = 0.0
+
+      linf(1) = 0.0  
+      linf(2) = 0.0  
+      linf(3) = 0.0
+      linf(4) = 0.0   
+      linf(5) = 0.0
+      linf(6) = 0.0
+
+      l2tol(1) = 5e-9
+      l2tol(2) = 5e-9 
+      l2tol(3) = 0.0
+      l2tol(4) = 5e-10
+      l2tol(5) = 0.0
+      l2tol(6) = 0.0
+
+      linftol(1) = 5e-9 
+      linftol(2) = 5e-9
+      linftol(3) = 0.0  
+      linftol(4) = 5e-10
+      linftol(5) = 0.0  
+      linftol(6) = 0.0
+
+
+      if (istep.le.10.or.mod(istep,iocomm).eq.0) then
+
+        call usersol(time   ,scn,scp,sce,dummy,dummy,dummy)
+        call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy) 
+        
+        call cem_error(cN,scN,errN,npts,l2(1),linf(1))
+        call cem_error(cP,scP,errP,npts,l2(2),linf(2))
+        call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
+ 
+        call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
+ 
+        if (istep.eq.nsteps) then
+        do i = 1,6
+           if (l2(i).gt.l2tol(i)) stop 1
+           if (linf(i).gt.linftol(i)) stop 1
+        enddo
+        endif
+
+      endif
+
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userprint(istep,tt,dt,l2,linf,t1,t2)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      integer istep
+      real tt,dt,t1,t2
+      real l2(6),linf(6)
+
+      integer k
+
+      if (nid.eq.0) then
+         write(6,101) istep,nelt,nx1-1,npts,tt,dt,(l2(k),k=1,6),t1,t2
+         write(6,102) istep,nelt,nx1-1,npts,tt,dt,(linf(k),k=1,6),t1,t2
+      endif
+
+ 101  format(/,i10,i6,i4,i9,1p9e10.3,e9.2,' CPU: L2')
+ 102  format(  i10,i6,i4,i9,1p9e10.3,e9.2,' CPU: Linf')
+
+      return
+      end
+
+

--- a/tests/drift2d/2dboxpecp.usr
+++ b/tests/drift2d/2dboxpecp.usr
@@ -21,10 +21,10 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
-      include 'DRIFT'  
+      include 'DRIFT'
       include 'NEKUSE'
-      include 'POISSON'  
-      
+      include 'POISSON'
+
       real tt
       real myhx(lx1*ly1*lz1*lelt)
       real myhy(lx1*ly1*lz1*lelt)
@@ -33,18 +33,17 @@ c-----------------------------------------------------------------------
       real myey(lx1*ly1*lz1*lelt)
       real myez(lx1*ly1*lz1*lelt)
 
-      tt=1.0
- 
-      do ie=1,nelt
-        do i= 1,nxyz
-          j = (ie-1)*nxyz+i
-          xx = xm1(i,1,1,ie)
-          yy = ym1(i,1,1,ie)
-          tmp = (sin(pi*xx)*sin(tt))**2
-          cN(j)= tmp      ! cN or potent
-          cP(j)= tmp*2.0  ! cP
-          cE(j)= 0.0      ! cE
-        enddo
+      tt = 1.0
+      do ie = 1,nelt
+         do i = 1,nxyz
+            j = (ie-1)*nxyz+i
+            xx = xm1(i,1,1,ie)
+            yy = ym1(i,1,1,ie)
+            tmp = (sin(pi*xx)*sin(tt))**2
+            cN(j) = tmp         ! cN or potent
+            cP(j) = tmp*2.0     ! cP
+            cE(j) = 0.0         ! cE
+         enddo
       enddo
 
       return
@@ -67,23 +66,23 @@ c-----------------------------------------------------------------------
       real mysey(lx1*ly1*lz1*lelt)
       real mysez(lx1*ly1*lz1*lelt)
 
-      real xx,yy,zz,tmp  
-      integer i,j,ie                          
-     
-      do ie=1,nelt 
-        do i= 1,nxyz
-          j = (ie-1)*nxyz+i
-          xx =  xm1(i,1,1,ie)
-          yy =  ym1(i,1,1,ie)
-          tmp = (sin(pi*xx)*sin(tt))**2
-          myshx(j)= tmp      ! cN or potent 
-          myshy(j)= tmp*2.0  ! cP
-          myshz(j)= 0.0      ! cE 
-          mysex(j)= 0.0      ! dummy
-          mysey(j)= 0.0      ! dummy
-          mysez(j)= 0.0      ! dummy
-        enddo
-      enddo 
+      real xx,yy,zz,tmp
+      integer i,j,ie
+
+      do ie = 1,nelt
+         do i = 1,nxyz
+            j = (ie-1)*nxyz+i
+            xx = xm1(i,1,1,ie)
+            yy = ym1(i,1,1,ie)
+            tmp = (sin(pi*xx)*sin(tt))**2
+            myshx(j) = tmp      ! cN or potent
+            myshy(j) = tmp*2.0  ! cP
+            myshz(j) = 0.0      ! cE
+            mysex(j) = 0.0      ! dummy
+            mysey(j) = 0.0      ! dummy
+            mysez(j) = 0.0      ! dummy
+         enddo
+      enddo
 
       return
       end
@@ -100,144 +99,142 @@ c-----------------------------------------------------------------------
       include 'RK5'
       include 'BCS'
       integer i,j,i0,baseidx
-      real    xx,yy,tt,pi2 
-      real    sinx,cosx2,sinx2,sint2,dudx,dudy,uu
-      real    tmp1,tmp2,tmp3,tmp4    
-      real    rhs_cn(1),rhs_cp(1),rhs_ce(1),rhs_phi(1)
-      real    nbc_cn(lx1*ly1*lz1*lelt)
-      real    nbc_cp(lx1*ly1*lz1*lelt)
-      real    nbc_ce(lx1*ly1*lz1*lelt)
-      real    nbc_phi(lx1*ly1*lz1*lelt)
+      real xx,yy,tt,pi2
+      real sinx,cosx2,sinx2,sint2,dudx,dudy,uu
+      real tmp1,tmp2,tmp3,tmp4
+      real rhs_cn(1),rhs_cp(1),rhs_ce(1),rhs_phi(1)
+      real nbc_cn(lx1*ly1*lz1*lelt)
+      real nbc_cp(lx1*ly1*lz1*lelt)
+      real nbc_ce(lx1*ly1*lz1*lelt)
+      real nbc_phi(lx1*ly1*lz1*lelt)
 
-      real    dumm1(1),dumm2(1)
-      real    unx0,uny0,unz0,area0
+      real dumm1(1),dumm2(1)
+      real unx0,uny0,unz0,area0
 
-c.....source for c_n,c_p,c_e at current step: time= istep*dt = time+dt
+c     Source for c_n,c_p,c_e at current step: time = istep*dt = time+dt
       if (ifrk) then
          tt=rktime
       else
-         tt=time+dt 
+         tt=time+dt
       endif
       pi2 = pi*pi
       do i=1,npts
-         xx    = xm1(i,1,1,1)
-         yy    = ym1(i,1,1,1)
-         sint2 = sin(tt)**2  
-         sinx  = sin(    pi*xx)
+         xx = xm1(i,1,1,1)
+         yy = ym1(i,1,1,1)
+         sint2 = sin(tt)**2
+         sinx = sin(pi*xx)
          sinx2 = sin(2.0*pi*xx)
          cosx2 = cos(2.0*pi*xx)
-         uu    = (sinx**2)*sint2               
-         dudx  = pi*sinx2 *sint2      
-         dudy  = 0.d0
+         uu = (sinx**2)*sint2
+         dudx = pi*sinx2 *sint2
+         dudy = 0.d0
 
-         tmp1  =  sin(2.0*tt)*sinx**2      ! dudt
-         tmp2  = -2.*pi2*sin(tt)**2*cosx2  !-laplace(u)  
-         tmp3  = (dudx**2+dudy**2)         ! grad(phi)*grad(u)
-         tmp4  = uu*(-tmp2)                ! u*laplace(phi)
+         tmp1 = sin(2.0*tt)*sinx**2 ! dudt
+         tmp2 = -2.*pi2*sin(tt)**2*cosx2 !-laplace(u)
+         tmp3 = (dudx**2+dudy**2) ! grad(phi)*grad(u)
+         tmp4 = uu*(-tmp2)      ! u*laplace(phi)
 
-         rhs_cn(i)=  tmp1+tmp2+tmp3+tmp4
-         rhs_cp(i)= (tmp1+tmp2-tmp3-tmp4)*2.0
-         rhs_ce(i)=  0.0             
+         rhs_cn(i) = tmp1+tmp2+tmp3+tmp4
+         rhs_cp(i) = (tmp1+tmp2-tmp3-tmp4)*2.0
+         rhs_ce(i) =  0.0
       enddo
       call col2(rhs_cN,bmn,npts)
       call col2(rhs_cP,bmn,npts)
 
-c.....source for Neumann boundary value at time 
+c     Source for Neumann boundary value at time
       if (ifrk) then
          tt=rktime
       else
-         tt=time+dt 
+         tt=time+dt
       endif
       call rzero(nbc_cn,npts)
       call rzero(nbc_cp,npts)
-      do i=1,ncemface_nmn(1)
-         j     = cemface_nmn(i,1)
-         i0    = cemface(j)
-         xx    = xm1(i0,1,1,1)
-         yy    = ym1(i0,1,1,1)
-         unx0  = unxm(j)
-         uny0  = unym(j)
+      do i = 1,ncemface_nmn(1)
+         j = cemface_nmn(i,1)
+         i0 = cemface(j)
+         xx = xm1(i0,1,1,1)
+         yy = ym1(i0,1,1,1)
+         unx0 = unxm(j)
+         uny0 = unym(j)
          area0 = aream(j)
-         sint2 = sin(tt)**2  
-         sinx  = sin(    pi*xx)
+         sint2 = sin(tt)**2
+         sinx = sin(pi*xx)
          sinx2 = sin(2.0*pi*xx)
          cosx2 = cos(2.0*pi*xx)
-         uu    = (sinx**2)*sint2           ! u
-         dudx  = pi*sinx2 *sint2      
-         dudy  = 0.d0
-         tmp1  =unx0*dudx+uny0*dudy
-         nbc_cn(i0)=tmp1*area0
-         tmp2  =(unx0*dudx+uny0*dudy)*2.0
-         nbc_cp(i0)=tmp2*area0
-      enddo 
+         uu = (sinx**2)*sint2   ! u
+         dudx = pi*sinx2 *sint2
+         dudy = 0.d0
+         tmp1 = unx0*dudx+uny0*dudy
+         nbc_cn(i0) = tmp1*area0
+         tmp2 = (unx0*dudx+uny0*dudy)*2.0
+         nbc_cp(i0) = tmp2*area0
+      enddo
       call add2s2(rhs_cn,nbc_cn,1.0,npts)
       call add2s2(rhs_cp,nbc_cp,1.0,npts)
 
-c.....source for potential field (phi) at time
-      tt= time
-      do i=1,npts
-         xx   = xm1(i,1,1,1)
-         yy   = ym1(i,1,1,1)
+c     Source for potential field (phi) at time
+      tt = time
+      do i = 1,npts
+         xx = xm1(i,1,1,1)
+         yy = ym1(i,1,1,1)
 
-         sint2 = sin(tt)**2  
+         sint2 = sin(tt)**2
          cosx2 = cos(2.0*pi*xx)
-         sinx  = sin(    pi*xx)
+         sinx = sin(pi*xx)
 
-         tmp1 = sinx**2*sint2       ! u
-         tmp2 =-2.0*pi**2*sint2*cosx2
+         tmp1 = sinx**2*sint2   ! u
+         tmp2 = -2.0*pi**2*sint2*cosx2
          tmp3 = tmp2-charge(i)*tmp1
          rhs_phi(i) = charge(i)*(cP(i)-cN(i))
          rhs_phi(i) = rhs_phi(i)+tmp3
       enddo
       call col2(rhs_phi,bmn,npts)
 
-c.....source for potential field (phi) with Neumann boundary value at time 
-      tt= time
+c     Source for potential field (phi) with Neumann boundary value at time
+      tt = time
       call rzero(nbc_phi,npts)
-      do i=1,ncemface_nmn(1)
-         j     = cemface_nmn(i,1)
-         i0    = cemface(j)
-         xx    = xm1(i0,1,1,1)
-         yy    = ym1(i0,1,1,1)
-         unx0  = unxm(j)
-         uny0  = unym(j)
+      do i = 1,ncemface_nmn(1)
+         j = cemface_nmn(i,1)
+         i0 = cemface(j)
+         xx = xm1(i0,1,1,1)
+         yy = ym1(i0,1,1,1)
+         unx0 = unxm(j)
+         uny0 = unym(j)
          area0 = aream(j)
-         sint2 = sin(tt)**2  
-         sinx  = sin(    pi*xx)
+         sint2 = sin(tt)**2
+         sinx = sin(pi*xx)
          sinx2 = sin(2.0*pi*xx)
          cosx2 = cos(2.0*pi*xx)
-         uu    = (sinx**2)*sint2           ! u
-         dudx  = pi*sinx2 *sint2      
-         dudy  = 0.d0
-         tmp1  =unx0*dudx+uny0*dudy
-         nbc_phi(i0)=tmp1*area0
-      enddo 
+         uu = (sinx**2)*sint2   ! u
+         dudx = pi*sinx2 *sint2
+         dudy = 0.d0
+         tmp1 = unx0*dudx+uny0*dudy
+         nbc_phi(i0) = tmp1*area0
+      enddo
       call add2s2(rhs_phi,nbc_phi,1.0,npts)
 
       return
       end
 c-----------------------------------------------------------------------
       subroutine uservp (ix,iy,iz,iel)
-c--------------------------------------------------------------------- 
+c---------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
-      include 'NEKUSE' 
-      include 'EMWAVE' 
+      include 'NEKUSE'
+      include 'EMWAVE'
       include 'DRIFT'
       include 'POISSON'
-      integer  i,j,k,l,ie,ieg
-      real     tmp
+      integer i,j,k,l,ie,ieg
+      real tmp
 
       if (ifsol) then
+         K_beta = 1.0
+         temperature = 1.0
+         tau_n = 1
+         tau_p = 1
 
-          K_beta      = 1.0
-          temperature = 1.0
-          tau_n       = 1
-          tau_p       = 1
-
-          call rone(d_permit,npts)
-          call rone(d_permea,npts)
-
+         call rone(d_permit,npts)
+         call rone(d_permea,npts)
       else
          if (nid.eq.0) write(6,*) 'this is exact solution case'
          call exitt
@@ -258,7 +255,7 @@ c-----------------------------------------------------------------------
       include 'EMWAVE'
       include 'NEKUSE'
       include 'GEOMBOUND'
-      real     rscale
+      real rscale
 
       n = nx1*ny1*nz1*nelt
 
@@ -269,14 +266,14 @@ c-----------------------------------------------------------------------
       zmin = glmin(zm1,n)
       zmax = glmax(zm1,n)
 
-      rscale =0.02 
+      rscale = 0.02
       sx = 100.0*rscale/(xmax-xmin)
-      sy = 100.0*rscale/(ymax-ymin)       
+      sy = 100.0*rscale/(ymax-ymin)
       if (nid.eq.0) write(6,*) 'sx/sy',sx,sy,rscale
-  
-      do i=1,n
-         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0               
-         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0                        
+
+      do i = 1,n
+         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0
+         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0
       enddo
 
       xmin = glmin(xm1,n)
@@ -300,9 +297,9 @@ c-----------------------------------------------------------------------
          yymid = ym1(mx,my,mz,ie)
 
          if (yymid.gt. 0) then
-             if_in_region(ie) =  1
+            if_in_region(ie) =  1
          else
-             if_in_region(ie) = -1
+            if_in_region(ie) = -1
          endif
 
       enddo
@@ -314,68 +311,63 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
-      include 'DRIFT' 
+      include 'DRIFT'
       include 'POISSON'
 
       common /ccpu/ cpu_t,cpu_dtime,cpu_chk
       real cpu_t,cpu_dtime,cpu_chk
-      
+
       integer i
       real l2(6),linf(6)
       real l2tol(6),linftol(6)
       real cpu_p_t
       real dummy(lx1*ly1*lz1*lelt)
 
-
-      l2(1) = 0.0  
-      l2(2) = 0.0  
+      l2(1) = 0.0
+      l2(2) = 0.0
       l2(3) = 0.0
-      l2(4) = 0.0   
+      l2(4) = 0.0
       l2(5) = 0.0
       l2(6) = 0.0
 
-      linf(1) = 0.0  
-      linf(2) = 0.0  
+      linf(1) = 0.0
+      linf(2) = 0.0
       linf(3) = 0.0
-      linf(4) = 0.0   
+      linf(4) = 0.0
       linf(5) = 0.0
       linf(6) = 0.0
 
       l2tol(1) = 5e-9
-      l2tol(2) = 5e-9 
+      l2tol(2) = 5e-9
       l2tol(3) = 0.0
       l2tol(4) = 5e-10
       l2tol(5) = 0.0
       l2tol(6) = 0.0
 
-      linftol(1) = 5e-9 
+      linftol(1) = 5e-9
       linftol(2) = 5e-9
-      linftol(3) = 0.0  
+      linftol(3) = 0.0
       linftol(4) = 5e-10
-      linftol(5) = 0.0  
+      linftol(5) = 0.0
       linftol(6) = 0.0
 
-
       if (istep.le.10.or.mod(istep,iocomm).eq.0) then
+         call usersol(time,scn,scp,sce,dummy,dummy,dummy)
+         call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy)
 
-        call usersol(time   ,scn,scp,sce,dummy,dummy,dummy)
-        call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy) 
-        
-        call cem_error(cN,scN,errN,npts,l2(1),linf(1))
-        call cem_error(cP,scP,errP,npts,l2(2),linf(2))
-        call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
- 
-        call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
- 
-        if (istep.eq.nsteps) then
-        do i = 1,6
-           if (l2(i).gt.l2tol(i)) stop 1
-           if (linf(i).gt.linftol(i)) stop 1
-        enddo
-        endif
+         call cem_error(cN,scN,errN,npts,l2(1),linf(1))
+         call cem_error(cP,scP,errP,npts,l2(2),linf(2))
+         call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
 
+         call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
+
+         if (istep.eq.nsteps) then
+            do i = 1,6
+               if (l2(i).gt.l2tol(i)) stop 1
+               if (linf(i).gt.linftol(i)) stop 1
+            enddo
+         endif
       endif
-
 
       return
       end
@@ -401,5 +393,3 @@ c-----------------------------------------------------------------------
 
       return
       end
-
-

--- a/tests/drift2d/SIZE
+++ b/tests/drift2d/SIZE
@@ -1,0 +1,182 @@
+c     Dimension file to be included     
+c                                       
+c     HCUBE array dimensions            
+                                        
+      integer    ldim, lxi, lx1, ly1, lz1, lelv, lelt, lp, lelg
+      integer    lxs, lys, lzs, lgmres,lfdm
+      parameter (ldim= 2)
+      parameter (lxi = 11 )  ! polynomial order
+      parameter (lx1 =lxi+1,ly1=lxi+1,lz1=1+lxi*(ldim-2))
+      parameter (lelv=64, lelt=lelv) 
+      parameter (lp  = 8)              
+      parameter (lelg=64)           
+      parameter (lxs=1,lys=lxs,lzs=(lxs-1)*(ldim-2)+1)
+      parameter (lgmres=30)!lx1*ly1*lz1*lelt)
+      parameter (lfdm  =0)  !global fast diagonalization method (1=on; 0=off)
+
+c     Choose meshes: if mesh=0 (hex/quad), if mesh=1 (tet/tri)
+c     Build  basis : DG (default), if nedelec=1 (nedelec)
+      integer    mesh, nedelec
+      parameter (mesh    = 0)
+      parameter (nedelec = 0)
+
+c     Arrays for new GEOM in TMPINPUT: temporary
+      integer    lpts,lxzfl,lxyzm
+      parameter (lpts = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl= lx1*lz1*2*ldim*lelt)
+      parameter (lxyzm= lx1*ly1*lz1        )
+
+c     Assign different size for different solvers
+      integer    lpts1,lxzfl1,lpts2,lxzfl2,lpts3,lxzfl3,lpts4,lxzfl4
+      integer    lpts5,lxzfl5,lfp,lxd,lyd,lzd
+      integer    lpts10,lxzfl10
+
+c     Arrays for Maxwell solver
+      parameter (lpts1 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl1= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Drude/Lorentz/Hydraulic Models with Maxwell
+      parameter (lpts10 = 1 )
+      parameter (lxzfl10= 1)
+
+c     Arrays for Schrodinger solver
+      parameter (lpts2 = 1) !(lpts2= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl2= 1) !(lxzfl2= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Acoustic solver
+      parameter (lpts3 = 1) !(lpts3= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl3= 1) !(lxzfl3= lx1*lz1*2*ldim*lelt)
+      parameter (lfp   = 1) ! fourier points for DtN operator
+
+c     Arrays for Drift-Diffusion solver
+      parameter (lpts4 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl4= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Nedelec solver
+C      parameter (lxd   =lx1*2,lyd=ly1*2,lzd=1)
+      parameter (lxd   =1,lyd=1,lzd=1)
+      parameter (lpts5 =1)! lxd*lyd*lzd*lelt   )
+      parameter (lxzfl5=1)! lxd*lzd*2*ldim*lelt)
+
+c     Arrays for Eigenvalue calculations: when not using set it as 1
+      integer    lpts_eig
+      parameter (lpts_eig= 1) ! (lpts_eig =lx1*ly1*lz1*lelt*2*ldim)
+
+c     Arrays for Quantum Model calculations
+      integer    level,lnumqd,lnumsp,lstate,lrho,leqn,lEh
+      parameter (level   = 1      )       ! number of qd states
+      parameter (lnumqd  = 1      )       ! number of surface plasmon states
+      parameter (lnumsp  = 1      )       ! number of surface plasmon states
+      parameter (lstate  = level**lnumqd*lnumsp)   ! number of total states
+      parameter (lrho    = lstate*lstate) ! number of rho
+      parameter (leqn    = 1      )       ! number of eqns: real/imag
+      parameter (lEh     = 1      )       ! number of energy
+
+c     Exponential Integrator
+      integer    larnol,luniform,levg,lelg2d,lmov,lw
+      parameter (larnol  = 1)
+      parameter (luniform= 1)
+      parameter (levg    = 1)
+      parameter (lelg2d  = 9)
+      parameter (lmov    = 0)
+      parameter (lw      = 5)
+
+c     Interpolation: lpart = the number of points for interpolation
+      integer    lpart
+      parameter (lpart= 1)
+
+c     Arrays for .box mesh                 
+      integer    lelx , lely , lelz
+      integer    lpelv, lpelt, lpert  
+      integer    lpx1 , lpy1 , lpz1 
+      integer    lpx2 , lpy2 , lpz2
+      integer    lbelt, lbelv 
+      integer    lbx1 , lby1 , lbz1 
+      integer    lbx2 , lby2 , lbz2 
+      parameter (lelx =8,lely =lelx ,lelz =1 )
+      parameter (lpelv=1,lpelt=lpelv,lpert=lpelv)
+      parameter (lpx1 =1,lpy1 =lpx1 ,lpz1 =lpx1 )
+      parameter (lpx2 =1,lpy2 =lpx2 ,lpz2 =lpx2 )
+      parameter (lbelv=lelv, lbelt=lelv )
+      parameter (lbx1 =1,lby1 =lbx1 ,lbz1 =lbx1 )
+      parameter (lbx2 =1,lby2 =lbx2 ,lbz2 =lbx2 )
+ 
+      integer    lzl
+      integer    lx2, ly2, lz2
+      integer    lx3, ly3, lz3
+      integer    lx1m, ly1m, lz1m
+      integer    ldimt, ldimt1, ldimt3
+
+      PARAMETER (LZL=1+2*(ldim-2))
+      PARAMETER (LX2=LX1)
+      PARAMETER (LY2=LY1)
+      PARAMETER (LZ2=LZ1)
+      PARAMETER (LX3=LX1)
+      PARAMETER (LY3=LY1)
+      PARAMETER (LZ3=LZ1)
+
+C     LX1M=LX1 when there are moving meshes; =1 otherwise
+      PARAMETER (LX1M  =1,LY1M=1,LZ1M=1)
+      PARAMETER (LDIMT =4)
+      PARAMETER (LDIMT1=LDIMT+1)
+      PARAMETER (LDIMT3=LDIMT+3)
+ 
+c
+c     Note:  In the new code, LELGEC should be about sqrt(LELG)
+c
+      integer    lelgec, lxyz2, lxz21
+      PARAMETER (LELGEC = 1)
+      PARAMETER (LXYZ2  = 1)
+      PARAMETER (LXZ21  = 1)
+c
+c     integer    lmaxv, lmaxt, lmaxp
+      integer    lxz, lorder, maxobj, maxmbr
+c     PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
+c     PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
+c     PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
+      PARAMETER (LXZ=LX1*LZ1)
+      PARAMETER (LORDER=3)              
+      PARAMETER (MAXOBJ=2,MAXMBR=LELT*6)
+C                                       
+C     Common Block Dimensions           
+C
+      integer    lctmp0, lctmp1
+      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)     
+      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
+C
+C     The parameter LVEC controls whether an additional 42 field arrays
+C     are required for Steady State Solutions.  If you are not using
+C     Steady State, it is recommended that LVEC=1.
+C
+      integer    lvec
+      PARAMETER (LVEC=1)
+C
+C     Uzawa projection array dimensions
+C
+c     PARAMETER (MXPREV = 01)
+C
+C     Split projection array dimensions
+C
+      integer    lmvec, lsvec, lstore
+      parameter (lmvec = 1)
+      parameter (lsvec = 1)
+      parameter (lstore=lmvec*lsvec)
+c
+c     NONCONFORMING STUFF
+c
+      integer    maxmor
+      parameter (maxmor = lelt)
+C
+C     Array dimensions                  
+C
+      integer    nelv, nelt
+      integer    nx1, ny1, nz1
+      integer    nx2, ny2, nz2
+      integer    nx3, ny3, nz3
+      integer    ndim, nfield, nid, npert
+      integer    nxyz, npts, nxzf, nxzfl, nfaces
+
+      COMMON /DIMN/
+     $           NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
+     $          ,NX3,NY3,NZ3,NDIM,NFIELD,NID,NPERT      
+     $          ,NXYZ,NPTS,NXZF,NXZFL,NFACES  

--- a/tests/drift3d/3dboxpecp.box
+++ b/tests/drift3d/3dboxpecp.box
@@ -1,0 +1,17 @@
+3dboxpecp.rea 
+3
+3                      number of fields
+#
+#    comments
+#
+#
+#========================================================
+#
+Box
+-8   -8   -8    (number of elements in x,y,z)
+-1   1   1              (x0,x1,gain)
+-1   1   1              (x0,x1,gain)
+-1   1   1              (x0,x1,gain)
+PEC,PEC,P  ,P  ,P  ,P             (bc's)
+PEC,PEC,P  ,P  ,P  ,P             (bc's)
+PEC,PEC,P  ,P  ,P  ,P             (bc's)

--- a/tests/drift3d/3dboxpecp.rea
+++ b/tests/drift3d/3dboxpecp.rea
@@ -1,0 +1,178 @@
+ ****** PARAMETERS *****
+    2.610000     NEKTON VERSION
+3 DIMENSIONAL RUN
+118 PARAMETERS FOLLOW
+  0                             1: ---
+  0                             2: ---
+  0                             3: ---
+  1                             4: x IFTE (1), IFTM (2)
+  30                            5: x IFMAXWELL=0,1,2,...;IFSCHROD=10,11,...; IFDRIFT=20,21,....,29(DG); IFDRIFT=30(w/o exciton),31(w/ exciton),39(SEM);
+  1                             6: x source turn on(1); turn off(0)
+  0                             7: x inhomogeneous boundary turn on (1)
+  3                             8: x # of field (default=0)
+  0                             9: ---
+  1e20                          10: x FINTIME: Final Time
+  100                           11: x NSTEPS: Total # of timesteps
+  -0.000001                     12: x DT:  Timestep Size with (-), eg. -0.05; CFL number with (+), eg, CFL=0.2,0.3,0.4
+  10                            13: x IOCOMM : Print statement at every IOCOMM step
+  0.000000E+00                  14: x OPTIONS: number of periods (nano)
+  10                           15: x IOSTEP : Produce outputs at every IOSTEP
+  1                             16: x IFSOL: 1 (solution assgined), 0 (if not)
+  -1                            17: x Timestep: 10(EIG),0 or 45(RK45),44(rk44),33(rk33),22(rk22), 1(EXP), -1(BDF1), -2(BDF2)
+  0                             18: x Filter: 0 (no filter), 1 (turn on filter), Dealias: -1 (turn on dealias)
+  0                             19: x FLUXES: 0 (upwind flux), 1 (central flux)
+  5.00000                       20: x ORDER (MESH): positive value
+  2                             21: x define poisson solver --> GMRES(1), CG(2), GMRES-SEMG(3); negative sign w/ projection GMRES(-1), CG(-2), GMRES-SEMG(-3)
+  1.E-8                        22: x tolerance      : (GMRES, CG, GMRES-SEMG)
+  1                             23: x preconditioner : FDM for CG(1)
+  2                             24: x define unsteady time dependent solver --> GMRES(1), CG(2); negative sign w/ projection GMRES(-1), CG(-2)                  
+  0                             25: x drift-diffusion GFDM (global fast diagonalization): GFDMDD (1)         
+  0                             26: ---  
+  3.00000                       27: x TORDER
+  0.000000E+00                  28: x TMESH
+  0.000000E+00                  29: ---
+  0.000000E+00                  30: ---
+  0.000000E+00                  31: ---
+  0.000000E+00                  32: ---
+  0                             33: ---
+  0                             34: ---
+  0                             35: ---
+  0                             36: ---
+  0                             37: ---
+  0.000000E+00                  38: ---
+  0.000000E+00                  39: ---
+  0.000000E+00                  40: ---
+  0.000000E+00                  41: ---
+  0.000000E+00                  42: ---
+  0                             43: ---
+  0.000000E+00                  44: ---
+  0.000000E+00                  45: ---
+  0.000000E+00                  46: ---
+  0.000000E+00                  47: ---
+  0.000000E+00                  48: ---
+  0.140000                      49: ---
+  0.000000E+00                  50: ---
+  0.000000E+00                  51: ---
+  0.000000E+00                  52: ---
+  0.000000E+00                  53: ---
+  0.000000E+00                  54: ---
+  0.000000E+00                  55: ---
+  0.000000E+00                  56: ---
+  0                             57: ---
+  0                             58: ---
+  0                             59: ---
+  0                             60: ---
+  0                             61: ---
+  0                             62: ---
+  0                             63: ---
+  0                             64: ---
+  0                             65: ---
+  0                             66: ---
+  0                             67: ---
+  0                             68: ---
+  0                             69: ---
+  0                             70: ---
+  0                             71: ---
+  0                             72: ---
+  0                             73: ---
+  0                             74: ---
+  0                             75: ---
+  0                             76: ---
+  1.000000E+00                  77: x PMLTHICK : thickness of the PML in levels
+  2.000000E+00                  78: x PMLORDER : polynomial order of the grading of the PML parameter sigma
+  1.000000E-05                  79: x PMLREFERR : PML reflection error
+  4                             80: x I/O: total (exact) number of output fields: currently default=4
+  0                             81: x I/O: 0 (no output), 1 (fld),2 (posix ascii),3 (posix binary), 4,5, (coIO), 6,-6,8 (rbIO)
+  1                             82: x I/O: the number of outputfiles per timestep
+  0                             83: x I/O: frequency of restart output files, 0 (no restart output), #nn (iostep*nn)
+  0                             84: x RESTART (should be 0 for non-mpi run): invoked with dump_number from the name of the restarting output file
+  0                             85: x computation trace active if positive number
+  0                             86: x io trace active if positive number
+  0                             87: x I/O: "1" on BGP ;if >0, write/read restart files in float; if 0 (=default), double
+  0                             88: ---
+  0                             89: ---
+  0                             90: ---
+  0                             91: ---
+  0                             92: ---
+  1                             93: x ifdielec  0: false 1: true
+  0                             94: x ific      0: false 1: true
+  0                             95: x ifpoisson 0: false 1: true
+  0                             96: ---
+  0                             97: --- x ifarpack 0: false 1: true
+  0                             98: ---
+  0                             99: ---
+  0                             100: x 0: default, 1: ifscat, 2: ifsftf
+  0                             101: x ifdrude 0: false 1: true
+  0                             102: ---
+  0                             103: ---
+  0                             104: ???
+  0                             105: ???
+  0                             106: ???
+  0                             107: ???
+  0                             108: ???
+  0                             109: ???
+  0                             110: ???
+  0                             111: ???
+  0                             112: ???
+  0                             113: ???
+  0                             114: ???
+  0                             115: ???
+  8                             116: ???
+  8                             117: ???
+  8                             118: ???
+			4  Lines of passive scalar data follows2 CONDUCT; 2RHOCP
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+13 LOGICAL SWITCHES FOLLOW
+  F                             1: IFFLOW
+  T                             2: IFHEAT
+  T                             3: IFTRAN
+  F                             4: IFSRC
+  T                             5: IFCENTRAL
+  F                             6: IFUPWIND
+  F                             7: IFTM (2D only)
+  T                             8: IFTE (2D only)
+  F                             9: IFDEALIAS
+  F                             10: IFRK4
+  T                             11: IFEXP
+  F                             12: IFEIG
+  F                             13: IFNM
+  9.23077       9.23077      -4.38462      -5.30769     XFAC,YFAC,XZERO,YZERO
+ **MESH DATA** 1st line is X of corner 1,2,3,4. 2nd line is Y.
+    9     -3     9          NEL,NDIM,NELV
+3dboxpecp.box
+            0 PRESOLVE/RESTART OPTIONS  *****
+            7         INITIAL CONDITIONS *****
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+  ***** DRIVE FORCE DATA ***** BODY FORCE, FLOW, Q
+            4                 Lines of Drive force data follow
+C                                                                               
+C                                                                               
+C                                                                               
+C                                                                               
+  ***** Variable Property Data ***** Overrrides Parameter data.
+            1 Lines follow.
+            0 PACKETS OF DATA FOLLOW
+  ***** HISTORY AND INTEGRAL DATA ***** 
+            0   POINTS.  Hcode, I,J,H,IEL
+  ***** OUTPUT FIELD SPECIFICATION *****
+            6 SPECIFICATIONS FOLLOW
+  F      COORDINATES
+  F      VELOCITY
+  F      PRESSURE
+  T      TEMPERATURE
+  F      TEMPERATURE GRADIENT
+            0      PASSIVE SCALARS
+  ***** OBJECT SPECIFICATION *****
+       0 Surface Objects 
+       0 Volume  Objects 
+       0 Edge    Objects 
+       0 Point   Objects 

--- a/tests/drift3d/3dboxpecp.usr
+++ b/tests/drift3d/3dboxpecp.usr
@@ -25,10 +25,10 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
-      include 'DRIFT'  
+      include 'DRIFT'
       include 'NEKUSE'
-      include 'POISSON'  
-      
+      include 'POISSON'
+
       real tt
       real myhx(lx1,ly1,lz1,lelt)
       real myhy(lx1,ly1,lz1,lelt)
@@ -39,7 +39,7 @@ c-----------------------------------------------------------------------
 
       tt= 1.0
 
-      do ie=1,nelt 
+      do ie=1,nelt
         do i=1,nxyz
           j=(ie-1)*nxyz+i
           xx= xm1(i,1,1,ie)
@@ -51,7 +51,7 @@ c-----------------------------------------------------------------------
           cE(j)=0.0
         enddo
       enddo
- 
+
       return
       end
 c-----------------------------------------------------------------------
@@ -64,18 +64,18 @@ c-----------------------------------------------------------------------
       include 'NEKUSE'
       include 'GEOMBOUND'
 
-      real myscN(lpts) 
-      real myscP(lpts) 
-      real myscE(lpts) 
+      real myscN(lpts)
+      real myscP(lpts)
+      real myscE(lpts)
 
       real mysex(lx1,ly1,lz1,lelt)
       real mysey(lx1,ly1,lz1,lelt)
       real mysez(lx1,ly1,lz1,lelt)
 
-      real xx,yy,zz,tt,tmp  
-      integer i,j,ie                          
-     
-      do ie = 1,nelt 
+      real xx,yy,zz,tt,tmp
+      integer i,j,ie
+
+      do ie = 1,nelt
         do i = 1,nxyz
           j = (ie-1)*nxyz+i
           xx = xm1(i,1,1,ie)
@@ -84,9 +84,9 @@ c-----------------------------------------------------------------------
           tmp = sin(pi*xx)*sin(pi*yy)*sin(pi*zz)*sin(tt)
           myscN(j) = tmp**2
           myscP(j) = 2.0*myscN(j)
-          myscE(j) = 0.0       
+          myscE(j) = 0.0
         enddo
-      enddo 
+      enddo
 
       return
       end
@@ -103,24 +103,24 @@ c-----------------------------------------------------------------------
       include 'DRIFT'
       include 'POISSON'
       integer i,baseidx
-      real    xx,yy,zz,tt,pi2 
+      real    xx,yy,zz,tt,pi2
       real    sinx,cosx2,sinx2,sint2,sinxyz2
-      real    siny,cosy2,siny2      
-      real    sinz,cosz2,sinz2      
-      real    sinxy2,sinyz2,sinxz2      
+      real    siny,cosy2,siny2
+      real    sinz,cosz2,sinz2
+      real    sinxy2,sinyz2,sinxz2
       real    dudx,dudy,dudz,uu
-      real    tmp1,tmp2,tmp3,tmp4    
+      real    tmp1,tmp2,tmp3,tmp4
       real    rhs_cn(1),rhs_cp(1),rhs_ce(1)
       real    rhs_phi(1), dummy1(1),dummy2(1)
 
 c.....source for c_n,c_p,c_e at current step: time= istep*dt = time+dt
-      tt=time+dt 
+      tt=time+dt
       pi2 = pi*pi
       do i=1,npts
          xx    = xm1(i,1,1,1)
          yy    = ym1(i,1,1,1)
          zz    = zm1(i,1,1,1)
-         sint2 = sin(tt)**2  
+         sint2 = sin(tt)**2
          sinx  = sin(    pi*xx)
          siny  = sin(    pi*yy)
          sinz  = sin(    pi*zz)
@@ -136,21 +136,21 @@ c.....source for c_n,c_p,c_e at current step: time= istep*dt = time+dt
          sinxz2=(sinx*sinz)**2
 
          uu    = sinxyz2*sint2             ! u
-         dudx  = pi*sinx2*sinyz2*sint2      
-         dudy  = pi*siny2*sinxz2*sint2      
-         dudz  = pi*sinz2*sinxy2*sint2      
+         dudx  = pi*sinx2*sinyz2*sint2
+         dudy  = pi*siny2*sinxz2*sint2
+         dudz  = pi*sinz2*sinxy2*sint2
 
          tmp1  =  sin(2.0*tt)*sinxyz2      ! dudt
          tmp2  = -2.*pi2*sint2*cosx2*sinyz2
      $           -2.*pi2*sint2*cosy2*sinxz2
      $           -2.*pi2*sint2*cosz2*sinxy2
-                   !-laplace(u)  
+                   !-laplace(u)
          tmp3  = (dudx**2+dudy**2+dudz**2) ! grad(phi)*grad(u)
          tmp4  = uu*(-tmp2)                ! u*laplace(phi)
 
          rhs_cn(i)=  tmp1+tmp2+tmp3+tmp4
          rhs_cp(i)= (tmp1+tmp2-tmp3-tmp4)*2.0
-         rhs_ce(i)=  0.0             
+         rhs_ce(i)=  0.0
       enddo
       call col2(rhs_cn,bmn,npts)
       call col2(rhs_cp,bmn,npts)
@@ -163,7 +163,7 @@ c.....source for potential field (phi) at time
          yy   = ym1(i,1,1,1)
          zz   = zm1(i,1,1,1)
 
-         sint2 = sin(tt)**2  
+         sint2 = sin(tt)**2
          cosx2 = cos(2.0*pi*xx)
          cosy2 = cos(2.0*pi*yy)
          cosz2 = cos(2.0*pi*zz)
@@ -188,11 +188,11 @@ c.....source for potential field (phi) at time
       end
 c-----------------------------------------------------------------------
       subroutine uservp (ix,iy,iz,iel)
-c--------------------------------------------------------------------- 
+c---------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
-      include 'NEKUSE' 
-      include 'EMWAVE' 
+      include 'NEKUSE'
+      include 'EMWAVE'
       include 'DRIFT'
       include 'POISSON'
       integer  i,j,k,l,ie,ieg
@@ -243,15 +243,15 @@ c-----------------------------------------------------------------------
       zmin = glmin(zm1,n)
       zmax = glmax(zm1,n)
 
-      rscale =0.02      !FIXME FOR TESTING     
+      rscale =0.02      !FIXME FOR TESTING
       sx = 100.0*rscale/(xmax-xmin)
-      sy = 100.0*rscale/(ymax-ymin)       
-      sz = 100.0*rscale/(zmax-zmin)       
+      sy = 100.0*rscale/(ymax-ymin)
+      sz = 100.0*rscale/(zmax-zmin)
 
       if (nid.eq.0) write(6,*) 'sx/sy',sx,sy,rscale
-  
+
       do i=1,n
-         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0               
+         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0
          ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0                        
          zm1(i,1,1,1) = sz*(zm1(i,1,1,1)-zmin)-1.0                        
       enddo
@@ -275,59 +275,57 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
-      include 'DRIFT' 
+      include 'DRIFT'
       include 'POISSON'
 
       common /ccpu/ cpu_t,cpu_dtime,cpu_chk
       real cpu_t,cpu_dtime,cpu_chk
-      
+
       integer i
       real l2(6),linf(6)
       real l2tol(6),linftol(6)
       real cpu_p_t
       real dummy(lx1*ly1*lz1*lelt)
 
-
-      l2(1) = 0.0  
-      l2(2) = 0.0  
+      l2(1) = 0.0
+      l2(2) = 0.0
       l2(3) = 0.0
-      l2(4) = 0.0   
+      l2(4) = 0.0
       l2(5) = 0.0
       l2(6) = 0.0
 
-      linf(1) = 0.0  
-      linf(2) = 0.0  
+      linf(1) = 0.0
+      linf(2) = 0.0
       linf(3) = 0.0
-      linf(4) = 0.0   
+      linf(4) = 0.0
       linf(5) = 0.0
       linf(6) = 0.0
 
       l2tol(1) = 5e-8
-      l2tol(2) = 5e-8 
-      l2tol(3) = 0   
-      l2tol(4) = 5e-8  
-      l2tol(5) = 0    
-      l2tol(6) = 0   
+      l2tol(2) = 6e-8
+      l2tol(3) = 0.0
+      l2tol(4) = 5e-11
+      l2tol(5) = 0.0
+      l2tol(6) = 0.0
 
-      linftol(1) = 5e-6 
-      linftol(2) = 5e-6
-      linftol(3) = 0    
-      linftol(4) = 5e-6 
-      linftol(5) = 0    
-      linftol(6) = 0   
-
+      linftol(1) = 5e-6
+      linftol(2) = 6e-6
+      linftol(3) = 0.0
+      linftol(4) = 5e-10
+      linftol(5) = 0.0
+      linftol(6) = 0.0
 
       if (istep.le.10.or.mod(istep,iocomm).eq.0) then
 
         call usersol(time   ,scn,scp,sce,dummy,dummy,dummy)
-        call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy) 
-        
+        call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy)
+
         call cem_error(cN,scN,errN,npts,l2(1),linf(1))
         call cem_error(cP,scP,errP,npts,l2(2),linf(2))
         call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
- 
+
         call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
- 
+
         if (istep.eq.nsteps) then
         do i = 1,6
            if (l2(i).gt.l2tol(i)) stop 1
@@ -362,5 +360,3 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-
-

--- a/tests/drift3d/3dboxpecp.usr
+++ b/tests/drift3d/3dboxpecp.usr
@@ -1,0 +1,366 @@
+c-----------------------------------------------------------------------
+c
+c  USER SPECIFIED ROUTINES:
+c
+c     - boundary conditions
+c     - initial conditions
+c     - variable properties
+c     - forcing function for fluid (f)
+c     - forcing function for passive scalar (q)
+c     - general purpose routine for checking errors etc.
+c
+c-----------------------------------------------------------------------
+      subroutine userinc
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userini(tt, myhx, myhy, myhz, myex, myey, myez)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'DRIFT'  
+      include 'NEKUSE'
+      include 'POISSON'  
+      
+      real tt
+      real myhx(lx1,ly1,lz1,lelt)
+      real myhy(lx1,ly1,lz1,lelt)
+      real myhz(lx1,ly1,lz1,lelt)
+      real myex(lx1,ly1,lz1,lelt)
+      real myey(lx1,ly1,lz1,lelt)
+      real myez(lx1,ly1,lz1,lelt)
+
+      tt= 1.0
+
+      do ie=1,nelt 
+        do i=1,nxyz
+          j=(ie-1)*nxyz+i
+          xx= xm1(i,1,1,ie)
+          yy= ym1(i,1,1,ie)
+          zz= zm1(i,1,1,ie)
+          tmp= sin(pi*xx)*sin(pi*yy)*sin(pi*zz)*sin(tt)
+          cN(j)=tmp**2
+          cP(j)=2.0*cN(j)
+          cE(j)=0.0
+        enddo
+      enddo
+ 
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersol(tt,myscn, myscp, mysce, mysex, mysey, mysez)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'DRIFT'
+      include 'NEKUSE'
+      include 'GEOMBOUND'
+
+      real myscN(lpts) 
+      real myscP(lpts) 
+      real myscE(lpts) 
+
+      real mysex(lx1,ly1,lz1,lelt)
+      real mysey(lx1,ly1,lz1,lelt)
+      real mysez(lx1,ly1,lz1,lelt)
+
+      real xx,yy,zz,tt,tmp  
+      integer i,j,ie                          
+     
+      do ie = 1,nelt 
+        do i = 1,nxyz
+          j = (ie-1)*nxyz+i
+          xx = xm1(i,1,1,ie)
+          yy = ym1(i,1,1,ie)
+          zz = zm1(i,1,1,ie)
+          tmp = sin(pi*xx)*sin(pi*yy)*sin(pi*zz)*sin(tt)
+          myscN(j) = tmp**2
+          myscP(j) = 2.0*myscN(j)
+          myscE(j) = 0.0       
+        enddo
+      enddo 
+
+      return
+      end
+
+
+c-----------------------------------------------------------------------
+      subroutine usersrc
+     $            (baseidx,rhs_cn,rhs_cp,rhs_ce,rhs_phi,dummy1,dummy2)     
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'DRIFT'
+      include 'POISSON'
+      integer i,baseidx
+      real    xx,yy,zz,tt,pi2 
+      real    sinx,cosx2,sinx2,sint2,sinxyz2
+      real    siny,cosy2,siny2      
+      real    sinz,cosz2,sinz2      
+      real    sinxy2,sinyz2,sinxz2      
+      real    dudx,dudy,dudz,uu
+      real    tmp1,tmp2,tmp3,tmp4    
+      real    rhs_cn(1),rhs_cp(1),rhs_ce(1)
+      real    rhs_phi(1), dummy1(1),dummy2(1)
+
+c.....source for c_n,c_p,c_e at current step: time= istep*dt = time+dt
+      tt=time+dt 
+      pi2 = pi*pi
+      do i=1,npts
+         xx    = xm1(i,1,1,1)
+         yy    = ym1(i,1,1,1)
+         zz    = zm1(i,1,1,1)
+         sint2 = sin(tt)**2  
+         sinx  = sin(    pi*xx)
+         siny  = sin(    pi*yy)
+         sinz  = sin(    pi*zz)
+         sinx2 = sin(2.0*pi*xx)
+         cosx2 = cos(2.0*pi*xx)
+         siny2 = sin(2.0*pi*yy)
+         cosy2 = cos(2.0*pi*yy)
+         sinz2 = sin(2.0*pi*zz)
+         cosz2 = cos(2.0*pi*zz)
+         sinxyz2=(sinx*siny*sinz)**2
+         sinxy2=(sinx*siny)**2
+         sinyz2=(siny*sinz)**2
+         sinxz2=(sinx*sinz)**2
+
+         uu    = sinxyz2*sint2             ! u
+         dudx  = pi*sinx2*sinyz2*sint2      
+         dudy  = pi*siny2*sinxz2*sint2      
+         dudz  = pi*sinz2*sinxy2*sint2      
+
+         tmp1  =  sin(2.0*tt)*sinxyz2      ! dudt
+         tmp2  = -2.*pi2*sint2*cosx2*sinyz2
+     $           -2.*pi2*sint2*cosy2*sinxz2
+     $           -2.*pi2*sint2*cosz2*sinxy2
+                   !-laplace(u)  
+         tmp3  = (dudx**2+dudy**2+dudz**2) ! grad(phi)*grad(u)
+         tmp4  = uu*(-tmp2)                ! u*laplace(phi)
+
+         rhs_cn(i)=  tmp1+tmp2+tmp3+tmp4
+         rhs_cp(i)= (tmp1+tmp2-tmp3-tmp4)*2.0
+         rhs_ce(i)=  0.0             
+      enddo
+      call col2(rhs_cn,bmn,npts)
+      call col2(rhs_cp,bmn,npts)
+      call col2(rhs_ce,bmn,npts)
+
+c.....source for potential field (phi) at time
+      tt= time
+      do i=1,npts
+         xx   = xm1(i,1,1,1)
+         yy   = ym1(i,1,1,1)
+         zz   = zm1(i,1,1,1)
+
+         sint2 = sin(tt)**2  
+         cosx2 = cos(2.0*pi*xx)
+         cosy2 = cos(2.0*pi*yy)
+         cosz2 = cos(2.0*pi*zz)
+         sinx  = sin(    pi*xx)
+         siny  = sin(    pi*yy)
+         sinz  = sin(    pi*zz)
+         sinxyz2=(sinx*siny*sinz)**2
+         sinxy2=(sinx*siny)**2
+         sinyz2=(siny*sinz)**2
+         sinxz2=(sinx*sinz)**2
+
+         tmp1  = sinxyz2*sint2           ! u
+         tmp2  = -2.*pi2*sint2*cosx2*sinyz2
+     $           -2.*pi2*sint2*cosy2*sinxz2
+     $           -2.*pi2*sint2*cosz2*sinxy2
+         tmp3 = tmp2-charge(i)*tmp1
+         rhs_phi(i) = charge(i)*(cP(i)-cN(i))
+         rhs_phi(i) = rhs_phi(i)+tmp3
+      enddo
+      call col2(rhs_phi,bmn,npts)
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine uservp (ix,iy,iz,iel)
+c--------------------------------------------------------------------- 
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE' 
+      include 'EMWAVE' 
+      include 'DRIFT'
+      include 'POISSON'
+      integer  i,j,k,l,ie,ieg
+      real     tmp
+
+      call rone(mu_n,npts)
+      call rone(mu_p,npts)
+      call rone(mu_e,npts)
+      call rone(ni,npts)
+
+      K_beta=1.0
+      temperature=1.0
+      tau_n = 1
+      tau_p = 1
+      call rone(charge,npts)
+      call rone(d_permit,npts)
+      call rone(d_permea,npts)
+
+      call copy(diff_n,mu_n,npts)
+      call copy(diff_p,mu_p,npts)
+      call copy(diff_e,mu_e,npts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat
+
+      return
+      end
+
+c-----------------------------------------------------------------------
+      subroutine usrdat2
+
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'GEOMBOUND'
+      real     rscale
+
+      n = nx1*ny1*nz1*nelv
+
+
+      xmin = glmin(xm1,n)
+      xmax = glmax(xm1,n)
+      ymin = glmin(ym1,n)
+      ymax = glmax(ym1,n)
+      zmin = glmin(zm1,n)
+      zmax = glmax(zm1,n)
+
+      rscale =0.02      !FIXME FOR TESTING     
+      sx = 100.0*rscale/(xmax-xmin)
+      sy = 100.0*rscale/(ymax-ymin)       
+      sz = 100.0*rscale/(zmax-zmin)       
+
+      if (nid.eq.0) write(6,*) 'sx/sy',sx,sy,rscale
+  
+      do i=1,n
+         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0               
+         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0                        
+         zm1(i,1,1,1) = sz*(zm1(i,1,1,1)-zmin)-1.0                        
+      enddo
+
+      xmin = glmin(xm1,n)
+      xmax = glmax(xm1,n)
+      ymin = glmin(ym1,n)
+      ymax = glmax(ym1,n)
+      zmin = glmin(zm1,n)
+      zmax = glmax(zm1,n)
+
+      if (nid.eq.0) write(6,*) 'xmin/xmax', xmin,xmax
+      if (nid.eq.0) write(6,*) 'ymin/ymax', ymin,ymax
+      if (nid.eq.0) write(6,*) 'zmin/zmax', zmin,zmax
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userchk
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'DRIFT' 
+      include 'POISSON'
+
+      common /ccpu/ cpu_t,cpu_dtime,cpu_chk
+      real cpu_t,cpu_dtime,cpu_chk
+      
+      integer i
+      real l2(6),linf(6)
+      real l2tol(6),linftol(6)
+      real cpu_p_t
+      real dummy(lx1*ly1*lz1*lelt)
+
+
+      l2(1) = 0.0  
+      l2(2) = 0.0  
+      l2(3) = 0.0
+      l2(4) = 0.0   
+      l2(5) = 0.0
+      l2(6) = 0.0
+
+      linf(1) = 0.0  
+      linf(2) = 0.0  
+      linf(3) = 0.0
+      linf(4) = 0.0   
+      linf(5) = 0.0
+      linf(6) = 0.0
+
+      l2tol(1) = 5e-8
+      l2tol(2) = 5e-8 
+      l2tol(3) = 0   
+      l2tol(4) = 5e-8  
+      l2tol(5) = 0    
+      l2tol(6) = 0   
+
+      linftol(1) = 5e-6 
+      linftol(2) = 5e-6
+      linftol(3) = 0    
+      linftol(4) = 5e-6 
+      linftol(5) = 0    
+      linftol(6) = 0   
+
+
+      if (istep.le.10.or.mod(istep,iocomm).eq.0) then
+
+        call usersol(time   ,scn,scp,sce,dummy,dummy,dummy)
+        call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy) 
+        
+        call cem_error(cN,scN,errN,npts,l2(1),linf(1))
+        call cem_error(cP,scP,errP,npts,l2(2),linf(2))
+        call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
+ 
+        call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
+ 
+        if (istep.eq.nsteps) then
+        do i = 1,6
+           if (l2(i).gt.l2tol(i)) stop 1
+           if (linf(i).gt.linftol(i)) stop 1
+        enddo
+        endif
+
+      endif
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userprint(istep,tt,dt,l2,linf,t1,t2)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      integer istep
+      real tt,dt,t1,t2
+      real l2(6),linf(6)
+
+      integer k
+
+      if (nid.eq.0) then
+         write(6,101) istep,nelt,nx1-1,npts,tt,dt,(l2(k),k=1,6),t1,t2
+         write(6,102) istep,nelt,nx1-1,npts,tt,dt,(linf(k),k=1,6),t1,t2
+      endif
+
+ 101  format(/,i10,i6,i4,i9,1p9e10.3,e9.2,' CPU: L2')
+ 102  format(  i10,i6,i4,i9,1p9e10.3,e9.2,' CPU: Linf')
+
+      return
+      end
+c-----------------------------------------------------------------------
+
+

--- a/tests/drift3d/3dboxpecp.usr
+++ b/tests/drift3d/3dboxpecp.usr
@@ -37,19 +37,19 @@ c-----------------------------------------------------------------------
       real myey(lx1,ly1,lz1,lelt)
       real myez(lx1,ly1,lz1,lelt)
 
-      tt= 1.0
+      tt = 1.0
 
-      do ie=1,nelt
-        do i=1,nxyz
-          j=(ie-1)*nxyz+i
-          xx= xm1(i,1,1,ie)
-          yy= ym1(i,1,1,ie)
-          zz= zm1(i,1,1,ie)
-          tmp= sin(pi*xx)*sin(pi*yy)*sin(pi*zz)*sin(tt)
-          cN(j)=tmp**2
-          cP(j)=2.0*cN(j)
-          cE(j)=0.0
-        enddo
+      do ie = 1,nelt
+         do i = 1,nxyz
+            j = (ie-1)*nxyz+i
+            xx = xm1(i,1,1,ie)
+            yy = ym1(i,1,1,ie)
+            zz = zm1(i,1,1,ie)
+            tmp = sin(pi*xx)*sin(pi*yy)*sin(pi*zz)*sin(tt)
+            cN(j) = tmp**2
+            cP(j) = 2.0*cN(j)
+            cE(j) = 0.0
+         enddo
       enddo
 
       return
@@ -76,22 +76,20 @@ c-----------------------------------------------------------------------
       integer i,j,ie
 
       do ie = 1,nelt
-        do i = 1,nxyz
-          j = (ie-1)*nxyz+i
-          xx = xm1(i,1,1,ie)
-          yy = ym1(i,1,1,ie)
-          zz = zm1(i,1,1,ie)
-          tmp = sin(pi*xx)*sin(pi*yy)*sin(pi*zz)*sin(tt)
-          myscN(j) = tmp**2
-          myscP(j) = 2.0*myscN(j)
-          myscE(j) = 0.0
-        enddo
+         do i = 1,nxyz
+            j = (ie-1)*nxyz+i
+            xx = xm1(i,1,1,ie)
+            yy = ym1(i,1,1,ie)
+            zz = zm1(i,1,1,ie)
+            tmp = sin(pi*xx)*sin(pi*yy)*sin(pi*zz)*sin(tt)
+            myscN(j) = tmp**2
+            myscP(j) = 2.0*myscN(j)
+            myscE(j) = 0.0
+         enddo
       enddo
 
       return
       end
-
-
 c-----------------------------------------------------------------------
       subroutine usersrc
      $            (baseidx,rhs_cn,rhs_cp,rhs_ce,rhs_phi,dummy1,dummy2)     
@@ -135,18 +133,17 @@ c.....source for c_n,c_p,c_e at current step: time= istep*dt = time+dt
          sinyz2=(siny*sinz)**2
          sinxz2=(sinx*sinz)**2
 
-         uu    = sinxyz2*sint2             ! u
+         uu    = sinxyz2*sint2  ! u
          dudx  = pi*sinx2*sinyz2*sint2
          dudy  = pi*siny2*sinxz2*sint2
          dudz  = pi*sinz2*sinxy2*sint2
 
-         tmp1  =  sin(2.0*tt)*sinxyz2      ! dudt
+         tmp1  =  sin(2.0*tt)*sinxyz2 ! dudt
          tmp2  = -2.*pi2*sint2*cosx2*sinyz2
      $           -2.*pi2*sint2*cosy2*sinxz2
      $           -2.*pi2*sint2*cosz2*sinxy2
-                   !-laplace(u)
          tmp3  = (dudx**2+dudy**2+dudz**2) ! grad(phi)*grad(u)
-         tmp4  = uu*(-tmp2)                ! u*laplace(phi)
+         tmp4  = uu*(-tmp2)     ! u*laplace(phi)
 
          rhs_cn(i)=  tmp1+tmp2+tmp3+tmp4
          rhs_cp(i)= (tmp1+tmp2-tmp3-tmp4)*2.0
@@ -156,7 +153,7 @@ c.....source for c_n,c_p,c_e at current step: time= istep*dt = time+dt
       call col2(rhs_cp,bmn,npts)
       call col2(rhs_ce,bmn,npts)
 
-c.....source for potential field (phi) at time
+c     Source for potential field (phi) at time
       tt= time
       do i=1,npts
          xx   = xm1(i,1,1,1)
@@ -175,7 +172,7 @@ c.....source for potential field (phi) at time
          sinyz2=(siny*sinz)**2
          sinxz2=(sinx*sinz)**2
 
-         tmp1  = sinxyz2*sint2           ! u
+         tmp1  = sinxyz2*sint2  ! u
          tmp2  = -2.*pi2*sint2*cosx2*sinyz2
      $           -2.*pi2*sint2*cosy2*sinxz2
      $           -2.*pi2*sint2*cosz2*sinxy2
@@ -195,8 +192,9 @@ c---------------------------------------------------------------------
       include 'EMWAVE'
       include 'DRIFT'
       include 'POISSON'
-      integer  i,j,k,l,ie,ieg
-      real     tmp
+
+      integer i,j,k,l,ie,ieg
+      real tmp
 
       call rone(mu_n,npts)
       call rone(mu_p,npts)
@@ -231,10 +229,10 @@ c-----------------------------------------------------------------------
       include 'EMWAVE'
       include 'NEKUSE'
       include 'GEOMBOUND'
-      real     rscale
+
+      real rscale
 
       n = nx1*ny1*nz1*nelv
-
 
       xmin = glmin(xm1,n)
       xmax = glmax(xm1,n)
@@ -243,7 +241,7 @@ c-----------------------------------------------------------------------
       zmin = glmin(zm1,n)
       zmax = glmax(zm1,n)
 
-      rscale =0.02      !FIXME FOR TESTING
+      rscale =0.02              ! FIXME FOR TESTING
       sx = 100.0*rscale/(xmax-xmin)
       sy = 100.0*rscale/(ymax-ymin)
       sz = 100.0*rscale/(zmax-zmin)
@@ -252,8 +250,8 @@ c-----------------------------------------------------------------------
 
       do i=1,n
          xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0
-         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0                        
-         zm1(i,1,1,1) = sz*(zm1(i,1,1,1)-zmin)-1.0                        
+         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0
+         zm1(i,1,1,1) = sz*(zm1(i,1,1,1)-zmin)-1.0
       enddo
 
       xmin = glmin(xm1,n)
@@ -316,23 +314,21 @@ c-----------------------------------------------------------------------
       linftol(6) = 0.0
 
       if (istep.le.10.or.mod(istep,iocomm).eq.0) then
+         call usersol(time   ,scn,scp,sce,dummy,dummy,dummy)
+         call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy)
 
-        call usersol(time   ,scn,scp,sce,dummy,dummy,dummy)
-        call usersol(time-dt,spotent,dummy,dummy,dummy,dummy,dummy)
+         call cem_error(cN,scN,errN,npts,l2(1),linf(1))
+         call cem_error(cP,scP,errP,npts,l2(2),linf(2))
+         call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
 
-        call cem_error(cN,scN,errN,npts,l2(1),linf(1))
-        call cem_error(cP,scP,errP,npts,l2(2),linf(2))
-        call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
+         call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
 
-        call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
-
-        if (istep.eq.nsteps) then
-        do i = 1,6
-           if (l2(i).gt.l2tol(i)) stop 1
-           if (linf(i).gt.linftol(i)) stop 1
-        enddo
-        endif
-
+         if (istep.eq.nsteps) then
+            do i = 1,6
+               if (l2(i).gt.l2tol(i)) stop 1
+               if (linf(i).gt.linftol(i)) stop 1
+            enddo
+         endif
       endif
 
       return

--- a/tests/drift3d/SIZE
+++ b/tests/drift3d/SIZE
@@ -1,0 +1,183 @@
+c     Dimension file to be included     
+c                                       
+c     HCUBE array dimensions            
+                                        
+      integer    ldim, lxi, lx1, ly1, lz1, lelv, lelt, lp, lelg
+      integer    lxs, lys, lzs, lgmres,lfdm
+      parameter (ldim=  3)
+      parameter (lxi =  9)  ! polynomial order
+      parameter (lx1 =lxi+1,ly1=lxi+1,lz1=1+lxi*(ldim-2))
+      parameter (lelv= 128, lelt=lelv) 
+      parameter (lp  = 8)              
+      parameter (lelg= 1024)           
+      parameter (lxs=1,lys=lxs,lzs=(lxs-1)*(ldim-2)+1)
+c      parameter (lgmres=lx1*ly1*lz1*lelt)
+      parameter (lgmres=100)
+      parameter (lfdm  =0)  !global fast diagonalization method (1=on; 0=off)
+
+c     Choose meshes: if mesh=0 (hex/quad), if mesh=1 (tet/tri)
+c     Build  basis : DG (default), if nedelec=1 (nedelec)
+      integer    mesh, nedelec
+      parameter (mesh    = 0)
+      parameter (nedelec = 0)
+
+c     Arrays for new GEOM in TMPINPUT: temporary
+      integer    lpts,lxzfl,lxyzm
+      parameter (lpts = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl= lx1*lz1*2*ldim*lelt)
+      parameter (lxyzm= lx1*ly1*lz1        )
+
+c     Assign different size for different solvers
+      integer    lpts1,lxzfl1,lpts2,lxzfl2,lpts3,lxzfl3,lpts4,lxzfl4
+      integer    lpts5,lxzfl5,lfp,lxd,lyd,lzd
+      integer    lpts10,lxzfl10
+
+c     Arrays for Maxwell solver
+      parameter (lpts1 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl1= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Drude/Lorentz/Hydraulic Models with Maxwell
+      parameter (lpts10 = 1)
+      parameter (lxzfl10= 1)
+
+c     Arrays for Schrodinger solver
+      parameter (lpts2 = 1) !(lpts2= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl2= 1) !(lxzfl2= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Acoustic solver
+      parameter (lpts3 = 1) !(lpts3= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl3= 1) !(lxzfl3= lx1*lz1*2*ldim*lelt)
+      parameter (lfp   = 1) ! fourier points for DtN operator
+
+c     Arrays for Drift-Diffusion solver
+      parameter (lpts4 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl4= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Nedelec solver
+c     parameter (lxd  =lx1*2,lyd=ly1*2,lzd=1)
+      parameter (lxd   =1,lyd=1,lzd=1)
+      parameter (lpts5 =1)! lxd*lyd*lzd*lelt   )
+      parameter (lxzfl5=1)! lxd*lzd*2*ldim*lelt)
+
+c     Arrays for Eigenvalue calculations: when not using set it as 1
+      integer    lpts_eig
+      parameter (lpts_eig= 1) ! (lpts_eig =lx1*ly1*lz1*lelt*2*ldim)
+
+c     Arrays for Quantum Model calculations
+      integer    level,lnumqd,lnumsp,lstate,lrho,leqn,lEh
+      parameter (level   = 1      )       ! number of qd states
+      parameter (lnumqd  = 1      )       ! number of surface plasmon states
+      parameter (lnumsp  = 1      )       ! number of surface plasmon states
+      parameter (lstate  = level**lnumqd*lnumsp)   ! number of total states
+      parameter (lrho    = lstate*lstate) ! number of rho
+      parameter (leqn    = 1      )       ! number of eqns: real/imag
+      parameter (lEh     = 1      )       ! number of energy
+
+c     Exponential Integrator
+      integer    larnol,luniform,levg,lelg2d,lmov,lw
+      parameter (larnol  = 1)
+      parameter (luniform= 1)
+      parameter (levg    = 1)
+      parameter (lelg2d  = 9)
+      parameter (lmov    = 0)
+      parameter (lw      = 5)
+
+c     Interpolation: lpart = the number of points for interpolation
+      integer    lpart
+      parameter (lpart= 1)
+
+c     Arrays for .box mesh                 
+      integer    lelx , lely , lelz
+      integer    lpelv, lpelt, lpert  
+      integer    lpx1 , lpy1 , lpz1 
+      integer    lpx2 , lpy2 , lpz2
+      integer    lbelt, lbelv 
+      integer    lbx1 , lby1 , lbz1 
+      integer    lbx2 , lby2 , lbz2 
+      parameter (lelx =8,lely =lelx ,lelz =lelx )
+      parameter (lpelv=1,lpelt=lpelv,lpert=lpelv)
+      parameter (lpx1 =1,lpy1 =lpx1 ,lpz1 =lpx1 )
+      parameter (lpx2 =1,lpy2 =lpx2 ,lpz2 =lpx2 )
+      parameter (lbelv=lelv, lbelt=lelv )
+      parameter (lbx1 =1,lby1 =lbx1 ,lbz1 =lbx1 )
+      parameter (lbx2 =1,lby2 =lbx2 ,lbz2 =lbx2 )
+ 
+      integer    lzl
+      integer    lx2, ly2, lz2
+      integer    lx3, ly3, lz3
+      integer    lx1m, ly1m, lz1m
+      integer    ldimt, ldimt1, ldimt3
+
+      PARAMETER (LZL=1+2*(ldim-2))
+      PARAMETER (LX2=LX1)
+      PARAMETER (LY2=LY1)
+      PARAMETER (LZ2=LZ1)
+      PARAMETER (LX3=LX1)
+      PARAMETER (LY3=LY1)
+      PARAMETER (LZ3=LZ1)
+
+C     LX1M=LX1 when there are moving meshes; =1 otherwise
+      PARAMETER (LX1M  =1,LY1M=1,LZ1M=1)
+      PARAMETER (LDIMT = 4)
+      PARAMETER (LDIMT1=LDIMT+1)
+      PARAMETER (LDIMT3=LDIMT+3)
+ 
+c
+c     Note:  In the new code, LELGEC should be about sqrt(LELG)
+c
+      integer    lelgec, lxyz2, lxz21
+      PARAMETER (LELGEC = 1)
+      PARAMETER (LXYZ2  = 1)
+      PARAMETER (LXZ21  = 1)
+c
+c     integer    lmaxv, lmaxt, lmaxp
+      integer    lxz, lorder, maxobj, maxmbr
+c     PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
+c     PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
+c     PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
+      PARAMETER (LXZ=LX1*LZ1)
+      PARAMETER (LORDER=3)              
+      PARAMETER (MAXOBJ=2,MAXMBR=LELT*6)
+C                                       
+C     Common Block Dimensions           
+C
+      integer    lctmp0, lctmp1
+      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)     
+      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
+C
+C     The parameter LVEC controls whether an additional 42 field arrays
+C     are required for Steady State Solutions.  If you are not using
+C     Steady State, it is recommended that LVEC=1.
+C
+      integer    lvec
+      PARAMETER (LVEC=1)
+C
+C     Uzawa projection array dimensions
+C
+c     PARAMETER (MXPREV = 01)
+C
+C     Split projection array dimensions
+C
+      integer    lmvec, lsvec, lstore
+      parameter (lmvec = 1)
+      parameter (lsvec = 1)
+      parameter (lstore=lmvec*lsvec)
+c
+c     NONCONFORMING STUFF
+c
+      integer    maxmor
+      parameter (maxmor = lelt)
+C
+C     Array dimensions                  
+C
+      integer    nelv, nelt
+      integer    nx1, ny1, nz1
+      integer    nx2, ny2, nz2
+      integer    nx3, ny3, nz3
+      integer    ndim, nfield, nid, npert
+      integer    nxyz, npts, nxzf, nxzfl, nfaces
+
+      COMMON /DIMN/
+     $           NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
+     $          ,NX3,NY3,NZ3,NDIM,NFIELD,NID,NPERT      
+     $          ,NXYZ,NPTS,NXZF,NXZFL,NFACES  

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -1,0 +1,128 @@
+{
+    "2dboxper-te": {
+	"dir": "2dboxper",
+	"usr": "2dboxper",
+	"rea": "2dboxper",
+	"params": {"4": 1}
+    },
+    "2dboxper-tm": {
+	"dir": "2dboxper",
+	"usr": "2dboxper",
+	"rea": "2dboxper",
+	"params": {"4": 2}
+    },
+    "2dboxpec-te": {
+	"dir": "2dboxpec",
+	"usr": "2dboxpec",
+	"rea": "2dboxpec",
+	"params": {"4": 1}
+    },
+    "2dboxpec-tm": {
+	"dir": "2dboxpec",
+	"usr": "2dboxpec",
+	"rea": "2dboxpec",
+	"params": {"4": 2}
+    },
+    "2dboxpml-te": {
+	"dir": "2dboxpml",
+	"usr": "2dboxpml",
+	"rea": "2dboxpml",
+	"params": {"4": 1}
+    },
+    "2dboxpml-tm": {
+	"dir": "2dboxpml",
+	"usr": "2dboxpml",
+	"rea": "2dboxpml",
+	"params": {"4": 2}
+    },
+    "2ddielectric-te-1mat": {
+	"dir": "2ddielectric",
+	"usr": "2ddielectric",
+	"rea": "2ddielectric",
+	"params": {"4": 1, "70": 0}
+    },
+    "2ddielectric-te-2mat": {
+	"dir": "2ddielectric",
+	"usr": "2ddielectric",
+	"rea": "2ddielectric",
+	"params": {"4": 1, "70": 1}
+    },
+    "2ddielectric-tm-1mat": {
+	"dir": "2ddielectric",
+	"usr": "2ddielectric",
+	"rea": "2ddielectric",
+	"params": {"4": 2, "70": 0}
+    },
+    "2ddielectric-tm-2mat": {
+	"dir": "2ddielectric",
+	"usr": "2ddielectric",
+	"rea": "2ddielectric",
+	"params": {"4": 2, "70": 1}
+    },
+    "3dboxper": {
+	"dir": "3dboxper",
+	"usr": "3dboxper",
+	"rea": "3dboxper",
+	"params": {}
+    },
+    "3dboxpec": {
+	"dir": "3dboxpec",
+	"usr": "3dboxpec",
+	"rea": "3dboxpec",
+	"params": {}
+    },
+    "3dboxpml": {
+	"dir": "3dboxpml",
+	"usr": "3dboxpml",
+	"rea": "3dboxpml",
+	"params": {}
+    },
+    "3ddielectric-1mat": {
+	"dir": "3ddielectric",
+	"usr": "3ddielectric",
+	"rea": "3ddielectric",
+	"params": {"70": 0}
+    },
+    "3ddielectric-2mat": {
+	"dir": "3ddielectric",
+	"usr": "3ddielectric",
+	"rea": "3ddielectric",
+	"params": {"70": 1}
+    },
+    "cylwave": {
+	"dir": "cylwave",
+	"usr": "cylwave",
+	"rea": "cylwave",
+	"params": {}
+    },
+    "drude": {
+	"dir": "drude",
+	"usr": "drude",
+	"rea": "drude",
+	"params": {}
+    },
+    "lorentz": {
+	"dir": "lorentz",
+	"usr": "lorentz",
+	"rea": "lorentz",
+	"params": {}
+    },
+    "graphene": {
+	"dir": "graphene",
+	"usr": "graphene",
+	"rea": "graphene",
+	"params": {}
+    },
+    "drift2d": {
+	"dir": "drift2d",
+	"usr": "2dboxpecp",
+	"rea": "2dboxpecp",
+	"params": {}
+    },
+    "drift3d": {
+	"dir": "drift3d",
+	"usr": "3dboxpecp",
+	"rea": "3dboxpecp",
+	"params": {}
+    }
+}


### PR DESCRIPTION
Takes the commits from https://github.com/NekCEM/NekCEM/pull/58 and adjusts the build framework so that arbitrary `.usr` filenames can be used. Then hooks up `drift2d` and `drift3d` to the tests framework. Also includes some minor whitespace fixes to make the stylechecker happy.