### PR TITLE
Unify the signatures of `.usr` routines for Maxwell applications

### DIFF
--- a/src/cem_maxwell.F
+++ b/src/cem_maxwell.F
@@ -472,26 +472,15 @@ c-----------------------------------------------------------------------
 #else
       call cem_maxwell
       call cem_maxwell_restrict_to_face
-      call cem_maxwell_add2
+      call userinc(rktime,fhn(1,1),fhn(1,2),fhn(1,3),
+     $                    fen(1,1),fen(1,2),fen(1,3))
       call cem_maxwell_flux(srflx)
       call cem_maxwell_add_flux_to_res(srflx)
       if (ifpml) call pml_step
-      call usersrc(rktime,reshn,resen)
+      call usersrc(rktime,reshn(1,1),reshn(1,2),reshn(1,3),
+     $                    resen(1,1),resen(1,2),resen(1,3))
       call cem_maxwell_invqmass
 #endif
-
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine cem_maxwell_add2
-c-----------------------------------------------------------------------
-      implicit none
-      include 'SIZE'
-      include 'TOTAL'
-      include 'EMWAVE'
-      include 'PML'
-
-      call userinc
 
       return
       end

--- a/tests/2dboxpec/2dboxpec.usr
+++ b/tests/2dboxpec/2dboxpec.usr
@@ -3,18 +3,26 @@ c
 c     Box geometry with a perfect electrical conductor on the boundary.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
-c-----------------------------------------------------------------------
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -31,7 +39,7 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt, myshx, myshy, myshz, mysex, mysey, mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -39,12 +47,8 @@ c-----------------------------------------------------------------------
       include 'EMWAVE'
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       real omega,tmph,tmpe
       real xx,yy,zz,u
@@ -67,12 +71,12 @@ c-----------------------------------------------------------------------
             yy = ym1(i,1,1,1)
             zz = zm1(i,1,1,1)
 
-            myshx(i,1,1,1) = cos(ww*xx)*sin(ww*yy)*tmph
-            myshy(i,1,1,1) = -sin(ww*xx)*cos(ww*yy)*tmph
-            myshz(i,1,1,1) = 0.0
-            mysex(i,1,1,1) = 0.0
-            mysey(i,1,1,1) = 0.0
-            mysez(i,1,1,1) = cos(ww*xx)*cos(ww*yy)*tmpe
+            solhx(i) = cos(ww*xx)*sin(ww*yy)*tmph
+            solhy(i) = -sin(ww*xx)*cos(ww*yy)*tmph
+            solhz(i) = 0.0
+            solex(i) = 0.0
+            soley(i) = 0.0
+            solez(i) = cos(ww*xx)*cos(ww*yy)*tmpe
          enddo
       elseif (ifte) then
          do i = 1,nx1*ny1*nz1*nelt
@@ -80,12 +84,12 @@ c-----------------------------------------------------------------------
             yy = ym1(i,1,1,1)
             zz = zm1(i,1,1,1)
 
-            myshx(i,1,1,1) = 0.0
-            myshy(i,1,1,1) = 0.0
-            myshz(i,1,1,1) = sin(ww*xx)*sin(ww*yy)*tmpe
-            mysex(i,1,1,1) = sin(ww*xx)*cos(ww*yy)*tmph
-            mysey(i,1,1,1) = -cos(ww*xx)*sin(ww*yy)*tmph
-            mysez(i,1,1,1) = 0.0
+            solhx(i) = 0.0
+            solhy(i) = 0.0
+            solhz(i) = sin(ww*xx)*sin(ww*yy)*tmpe
+            solex(i) = sin(ww*xx)*cos(ww*yy)*tmph
+            soley(i) = -cos(ww*xx)*sin(ww*yy)*tmph
+            solez(i) = 0.0
          enddo
       else
          write(*,*) 'ERROR: usersol: invalid imode'
@@ -95,22 +99,17 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt, myhx, myhy, myhz, myex, myey, myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
-      include 'EMWAVE'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
-      call usersol(tt,myhx, myhy, myhz, myex, myey, myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 
       return
       end
@@ -141,6 +140,8 @@ c     is resolved.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
+
       return
       end
 c-----------------------------------------------------------------------

--- a/tests/2dboxper/2dboxper.usr
+++ b/tests/2dboxper/2dboxper.usr
@@ -3,12 +3,34 @@ c
 c     Box geometry with periodic boundary conditions.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+
+      real tt
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
+
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -16,32 +38,8 @@ c-----------------------------------------------------------------------
       include 'EMWAVE'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
-
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
-
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
-c-----------------------------------------------------------------------
-      implicit none
-      include 'SIZE'
-      include 'TOTAL'
-      include 'EMWAVE'
-
-      real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       real omega,tmph,tmpe
       real xx,yy,zz,u
@@ -57,12 +55,12 @@ c-----------------------------------------------------------------------
             yy = ym1(i,1,1,1)
             zz = zm1(i,1,1,1)
 
-            myshx(i,1,1,1) = cos(xx)*sin(yy)*tmph
-            myshy(i,1,1,1) = -sin(xx)*cos(yy)*tmph
-            myshz(i,1,1,1) = 0.0
-            mysex(i,1,1,1) = 0.0
-            mysey(i,1,1,1) = 0.0
-            mysez(i,1,1,1) = cos(xx)*cos(yy)*tmpe
+            solhx(i) = cos(xx)*sin(yy)*tmph
+            solhy(i) = -sin(xx)*cos(yy)*tmph
+            solhz(i) = 0.0
+            solex(i) = 0.0
+            soley(i) = 0.0
+            solez(i) = cos(xx)*cos(yy)*tmpe
          enddo
       elseif (ifte) then
          tmph = cos(omega*tt)
@@ -73,12 +71,12 @@ c-----------------------------------------------------------------------
             yy = ym1(i,1,1,1)
             zz = zm1(i,1,1,1)
 
-            myshx(i,1,1,1) = 0.0
-            myshy(i,1,1,1) = 0.0
-            myshz(i,1,1,1) = sin(xx)*sin(yy)*tmph
-            mysex(i,1,1,1) = sin(xx)*cos(yy)*tmpe
-            mysey(i,1,1,1) = -cos(xx)*sin(yy)*tmpe
-            mysez(i,1,1,1) = 0.0
+            solhx(i) = 0.0
+            solhy(i) = 0.0
+            solhz(i) = sin(xx)*sin(yy)*tmph
+            solex(i) = sin(xx)*cos(yy)*tmpe
+            soley(i) = -cos(xx)*sin(yy)*tmpe
+            solez(i) = 0.0
          enddo
       else
          write(*,*) 'ERROR: usersol: invalid imode'
@@ -88,13 +86,14 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -137,6 +136,8 @@ c     is resolved.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
+
       return
       end
 c-----------------------------------------------------------------------

--- a/tests/2dboxpml/2dboxpml.usr
+++ b/tests/2dboxpml/2dboxpml.usr
@@ -3,28 +3,31 @@ c
 c     Box geometry with a PML on the boundary and a dipole source.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
-c-----------------------------------------------------------------------
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
 c     For the TM case, a Gaussian approximation to a line current
 c     source. The distribution from the line current is
@@ -43,7 +46,8 @@ c     "current", which of course doesn't really exist.
       include 'EMWAVE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       integer i
       real tfac,tconst,xx,yy,xfac,yfac,src
@@ -66,9 +70,9 @@ c     Normalization constant
          src = i0*norm*exp(xfac+yfac)*tconst
 
          if (ifte) then
-            srchn(i,3) = srchn(i,3)-src
+            srchz(i) = srchz(i)-src
          elseif (iftm) then
-            srcen(i,3) = srcen(i,3)-src
+            srcez(i) = srcez(i)-src
          else
             write(*,*) 'ERROR: usersrc: invalid imode'
             call exitt
@@ -90,25 +94,21 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
-      call rzero(myhx,lx1*ly1*lz1*lelt)
-      call rzero(myhy,lx1*ly1*lz1*lelt)
-      call rzero(myhz,lx1*ly1*lz1*lelt)
-      call rzero(myex,lx1*ly1*lz1*lelt)
-      call rzero(myey,lx1*ly1*lz1*lelt)
-      call rzero(myez,lx1*ly1*lz1*lelt)
+      call rzero(hx,lpts)
+      call rzero(hy,lpts)
+      call rzero(hz,lpts)
+      call rzero(ex,lpts)
+      call rzero(ey,lpts)
+      call rzero(ez,lpts)
 
       return
       end
@@ -139,6 +139,8 @@ c     is resolved.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
+
       return
       end
 c-----------------------------------------------------------------------

--- a/tests/2ddielectric/2ddielectric.usr
+++ b/tests/2ddielectric/2ddielectric.usr
@@ -3,7 +3,7 @@ c
 c     Normally-incident plane wave striking a dielectric interface.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -17,9 +17,13 @@ c-----------------------------------------------------------------------
       common /userincvars/ incindex,ninc
       integer incindex(lxzfl),ninc
 
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
       integer i,j,k
       real ky
-      real yy,tt,mu,eps,eta,uinc
+      real yy,mu,eps,eta,uinc
 
       tt = rktime
       do i = 1,ninc
@@ -32,18 +36,18 @@ c-----------------------------------------------------------------------
          ky = omega*sqrt(mu*eps)
          uinc = cos(-ky*yy-omega*tt)
          if (ifte) then
-            fhn(j,3) = fhn(j,3)+uinc
-            fen(j,1) = fen(j,1)+eta*uinc
+            incfhz(j) = incfhz(j)+uinc
+            incfex(j) = incfex(j)+eta*uinc
          else
-            fen(j,3) = fen(j,3)+uinc
-            fhn(j,1) = fhn(j,1)-uinc/eta
+            incfez(j) = incfez(j)+uinc
+            incfhx(j) = incfhx(j)-uinc/eta
          endif
       enddo
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -52,33 +56,29 @@ c-----------------------------------------------------------------------
       include 'PML'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
       integer i
       real mu,eps
 
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 c     We need to set the extra PML fields too
       do i = 1,npts
          mu = permeability(i)
          eps = permittivity(i)
-         pmlbn(i,1) = mu*myhx(i,1,1,1)
-         pmlbn(i,2) = mu*myhy(i,1,1,1)
-         pmlbn(i,3) = mu*myhz(i,1,1,1)
-         pmldn(i,1) = eps*myex(i,1,1,1)
-         pmldn(i,2) = eps*myey(i,1,1,1)
-         pmldn(i,3) = eps*myez(i,1,1,1)
+         pmlbn(i,1) = mu*hx(i)
+         pmlbn(i,2) = mu*hy(i)
+         pmlbn(i,3) = mu*hz(i)
+         pmldn(i,1) = eps*ex(i)
+         pmldn(i,2) = eps*ey(i)
+         pmldn(i,3) = eps*ez(i)
       enddo
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -90,12 +90,8 @@ c-----------------------------------------------------------------------
       real omega,eps1,eps2,mu1,mu2,refl,tran
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       integer e,i,j,l,lx1_2
       real ky,uu
@@ -124,11 +120,11 @@ c     Global number
                   endif
                   uu = refl*exp(-eta*pmlfac)*cos(ky*yy-omega*tt)
                   if (ifte) then
-                     myshz(i,j,1,e) = uu
-                     mysex(i,j,1,e) = -eta*uu
+                     solhz(l) = uu
+                     solex(l) = -eta*uu
                   else
-                     mysez(i,j,1,e) = uu
-                     myshx(i,j,1,e) = uu/eta
+                     solez(l) = uu
+                     solhx(l) = uu/eta
                   endif
                else
                   if (pmltag(e).ne.0) then
@@ -142,11 +138,11 @@ c     Global number
                   endif
                   uu = tran*exp(-eta*pmlfac)*cos(-ky*yy-omega*tt)
                   if (ifte) then
-                     myshz(i,j,1,e) = uu
-                     mysex(i,j,1,e) = eta*uu
+                     solhz(l) = uu
+                     solex(l) = eta*uu
                   else
-                     mysez(i,j,1,e) = uu
-                     myshx(i,j,1,e) = -uu/eta
+                     solez(l) = uu
+                     solhx(l) = -uu/eta
                   endif
                endif
             enddo
@@ -156,13 +152,14 @@ c     Global number
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -293,6 +290,8 @@ c     k is the volume global number associated with face j.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
+
       return
       end
 c-----------------------------------------------------------------------

--- a/tests/3dboxpec/3dboxpec.usr
+++ b/tests/3dboxpec/3dboxpec.usr
@@ -10,18 +10,26 @@ c     - forcing function for passive scalar (q)
 c     - general purpose routine for checking errors etc.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
-c-----------------------------------------------------------------------
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -38,27 +46,22 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
-      include 'EMWAVE'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
-      call usersol(tt,myhx, myhy, myhz, myex, myey, myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt, myshx, myshy, myshz, mysex, mysey, mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -66,12 +69,8 @@ c-----------------------------------------------------------------------
       include 'EMWAVE'
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       real omega,rtomega
       real tmph,tmpe
@@ -101,12 +100,12 @@ c-----------------------------------------------------------------------
             yy = ym1(i,1,1,1)
             zz = zm1(i,1,1,1)
 
-            myshx(i,1,1,1) = -sin(ww*xx)*cos(ww*yy)*cos(ww*zz)*tmph
-            myshy(i,1,1,1) = -cos(ww*xx)*sin(ww*yy)*cos(ww*zz)*tmph
-            myshz(i,1,1,1) = 2*cos(ww*xx)*cos(ww*yy)*sin(ww*zz)*tmph
-            mysex(i,1,1,1) = -cos(ww*xx)*sin(ww*yy)*sin(ww*zz)*tmpe
-            mysey(i,1,1,1) = sin(ww*xx)*cos(ww*yy)*sin(ww*zz)*tmpe
-            mysez(i,1,1,1) = 0
+            solhx(i) = -sin(ww*xx)*cos(ww*yy)*cos(ww*zz)*tmph
+            solhy(i) = -cos(ww*xx)*sin(ww*yy)*cos(ww*zz)*tmph
+            solhz(i) = 2*cos(ww*xx)*cos(ww*yy)*sin(ww*zz)*tmph
+            solex(i) = -cos(ww*xx)*sin(ww*yy)*sin(ww*zz)*tmpe
+            soley(i) = sin(ww*xx)*cos(ww*yy)*sin(ww*zz)*tmpe
+            solez(i) = 0
          enddo
 
       else
@@ -123,12 +122,12 @@ c-----------------------------------------------------------------------
                yy = ym1(i,1,1,1)
                zz = zm1(i,1,1,1)
 
-               myshx(i,1,1,1) = cos(ww*xx)*sin(ww*yy)*tmph
-               myshy(i,1,1,1) = -sin(ww*xx)*cos(ww*yy)*tmph
-               myshz(i,1,1,1) = 0.0
-               mysex(i,1,1,1) = 0.0
-               mysey(i,1,1,1) = 0.0
-               mysez(i,1,1,1) = cos(ww*xx)*cos(ww*yy)*tmpe
+               solhx(i) = cos(ww*xx)*sin(ww*yy)*tmph
+               solhy(i) = -sin(ww*xx)*cos(ww*yy)*tmph
+               solhz(i) = 0.0
+               solex(i) = 0.0
+               soley(i) = 0.0
+               solez(i) = cos(ww*xx)*cos(ww*yy)*tmpe
             enddo
          elseif (ifte) then
             do i = 1,nx1*ny1*nz1*nelt
@@ -136,12 +135,12 @@ c-----------------------------------------------------------------------
                yy = ym1(i,1,1,1)
                zz = zm1(i,1,1,1)
 
-               myshx(i,1,1,1) = 0.0
-               myshy(i,1,1,1) = 0.0
-               myshz(i,1,1,1) = sin(ww*xx)*sin(ww*yy)*tmpe
-               mysex(i,1,1,1) = sin(ww*xx)*cos(ww*yy)*tmph
-               mysey(i,1,1,1) = -cos(ww*xx)*sin(ww*yy)*tmph
-               mysez(i,1,1,1) = 0.0
+               solhx(i) = 0.0
+               solhy(i) = 0.0
+               solhz(i) = sin(ww*xx)*sin(ww*yy)*tmpe
+               solex(i) = sin(ww*xx)*cos(ww*yy)*tmph
+               soley(i) = -cos(ww*xx)*sin(ww*yy)*tmph
+               solez(i) = 0.0
             enddo
          else
             call exitt
@@ -227,7 +226,7 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
       include 'EMWAVE'
 
-      common /ccpu/  cpu_t,cpu_dtime,cpu_chk
+      common /ccpu/ cpu_t,cpu_dtime,cpu_chk
       real cpu_t,cpu_dtime,cpu_chk
 
       integer i

--- a/tests/3dboxper/3dboxper.usr
+++ b/tests/3dboxper/3dboxper.usr
@@ -10,18 +10,26 @@ c     - forcing function for passive scalar (q)
 c     - general purpose routine for checking errors etc.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
-c-----------------------------------------------------------------------
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -38,19 +46,15 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt, myshx, myshy, myshz, mysex, mysey, mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       real omega,tmph,tmpe
       real xx,yy,zz,u
@@ -67,12 +71,12 @@ c-----------------------------------------------------------------------
             yy = ym1(i,1,1,1)
             zz = zm1(i,1,1,1)
 
-            myshx(i,1,1,1) = 2*cos(xx)*sin(yy)*cos(zz)*tmph
-            myshy(i,1,1,1) = -sin(xx)*cos(yy)*cos(zz)*tmph
-            myshz(i,1,1,1) = sin(xx)*sin(yy)*sin(zz)*tmph
-            mysex(i,1,1,1) = 0.0
-            mysey(i,1,1,1) = cos(xx)*sin(yy)*sin(zz)*tmpe
-            mysez(i,1,1,1) = cos(xx)*cos(yy)*cos(zz)*tmpe
+            solhx(i) = 2*cos(xx)*sin(yy)*cos(zz)*tmph
+            solhy(i) = -sin(xx)*cos(yy)*cos(zz)*tmph
+            solhz(i) = sin(xx)*sin(yy)*sin(zz)*tmph
+            solex(i) = 0.0
+            soley(i) = cos(xx)*sin(yy)*sin(zz)*tmpe
+            solez(i) = cos(xx)*cos(yy)*cos(zz)*tmpe
          enddo
       else
          omega = 2
@@ -87,12 +91,12 @@ c-----------------------------------------------------------------------
                yy = ym1(i,1,1,1)
                zz = zm1(i,1,1,1)
 
-               myshx(i,1,1,1) = 2*cos(xx)*sin(yy)*tmph
-               myshy(i,1,1,1) = -sin(xx)*cos(yy)*tmph
-               myshz(i,1,1,1) = 0.0
-               mysex(i,1,1,1) = 0.0
-               mysey(i,1,1,1) = 0.0
-               mysez(i,1,1,1) = cos(xx)*cos(yy)*tmpe
+               solhx(i) = 2*cos(xx)*sin(yy)*tmph
+               solhy(i) = -sin(xx)*cos(yy)*tmph
+               solhz(i) = 0.0
+               solex(i) = 0.0
+               soley(i) = 0.0
+               solez(i) = cos(xx)*cos(yy)*tmpe
             enddo
          elseif (ifte) then
             tmph = cos(omega*tt)
@@ -103,12 +107,12 @@ c-----------------------------------------------------------------------
                yy = ym1(i,1,1,1)
                zz = zm1(i,1,1,1)
 
-               myshx(i,1,1,1) = 0.0
-               myshy(i,1,1,1) = 0.0
-               myshz(i,1,1,1) = sin(xx)*sin(yy)*tmph
-               mysex(i,1,1,1) = sin(xx)*cos(yy)*tmpe
-               mysey(i,1,1,1) = -cos(xx)*sin(yy)*tmpe
-               mysez(i,1,1,1) = 0.0
+               solhx(i) = 0.0
+               solhy(i) = 0.0
+               solhz(i) = sin(xx)*sin(yy)*tmph
+               solex(i) = sin(xx)*cos(yy)*tmpe
+               soley(i) = -cos(xx)*sin(yy)*tmpe
+               solez(i) = 0.0
             enddo
          else
             call exitt
@@ -119,21 +123,17 @@ c-----------------------------------------------------------------------
       end
 
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 
       return
       end
@@ -164,6 +164,8 @@ c     is resolved.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
+
       return
       end
 c-----------------------------------------------------------------------

--- a/tests/3dboxpml/3dboxpml.usr
+++ b/tests/3dboxpml/3dboxpml.usr
@@ -3,28 +3,31 @@ c
 c     Box geometry with a PML on the boundary and a dipole source.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
-c-----------------------------------------------------------------------
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
 c     Gaussian approximation to a Hertzian dipole. The current
 c     distribution from the dipole is
@@ -41,7 +44,8 @@ c     purposes.
       include 'EMWAVE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       integer i
       real tfac,tconst,xx,yy,zz,xfac,yfac,zfac
@@ -66,7 +70,7 @@ c     Normalization constant
          yfac = -0.5*((yy-yloc)/width)**2
          zfac = -0.5*((zz-zloc)/width)**2
 
-         srcen(i,3) = srcen(i,3)-i0*norm*exp(xfac+yfac+zfac)*tconst
+         srcez(i) = srcez(i)-i0*norm*exp(xfac+yfac+zfac)*tconst
       enddo
 
       return
@@ -84,25 +88,21 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
-      call rzero(myhx,lx1*ly1*lz1*lelt)
-      call rzero(myhy,lx1*ly1*lz1*lelt)
-      call rzero(myhz,lx1*ly1*lz1*lelt)
-      call rzero(myex,lx1*ly1*lz1*lelt)
-      call rzero(myey,lx1*ly1*lz1*lelt)
-      call rzero(myez,lx1*ly1*lz1*lelt)
+      call rzero(hx,lpts)
+      call rzero(hy,lpts)
+      call rzero(hz,lpts)
+      call rzero(ex,lpts)
+      call rzero(ey,lpts)
+      call rzero(ez,lpts)
 
       return
       end
@@ -133,6 +133,8 @@ c     is resolved.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
+
       return
       end
 c-----------------------------------------------------------------------

--- a/tests/3ddielectric/3ddielectric.usr
+++ b/tests/3ddielectric/3ddielectric.usr
@@ -3,7 +3,7 @@ c
 c     Normally-incident plane wave striking a dielectric interface.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -18,11 +18,14 @@ c-----------------------------------------------------------------------
       common /userincvars/ incindex,ninc
       integer incindex(lxzfl),ninc
 
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
       integer i,j,k
       real ky
-      real yy,tt,mu,eps,eta,uinc
+      real yy,mu,eps,eta,uinc
 
-      tt = rktime
       do i = 1,ninc
          j = incindex(i)
          k = cemface(j)
@@ -32,16 +35,16 @@ c-----------------------------------------------------------------------
          eta = sqrt(mu/eps)
          ky = omega*sqrt(mu*eps)
          uinc = cos(-ky*yy-omega*tt)
-         fhn(j,3) = fhn(j,3)+uinc
-         fen(j,1) = fen(j,1)+eta*uinc
-         fen(j,3) = fen(j,3)+uinc
-         fhn(j,1) = fhn(j,1)-uinc/eta
+         incfhz(j) = incfhz(j)+uinc
+         incfex(j) = incfex(j)+eta*uinc
+         incfez(j) = incfez(j)+uinc
+         incfhx(j) = incfhx(j)-uinc/eta
       enddo
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -50,33 +53,29 @@ c-----------------------------------------------------------------------
       include 'PML'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
       integer i
       real mu,eps
 
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 c     We need to set the extra PML fields too
       do i = 1,npts
          mu = permeability(i)
          eps = permittivity(i)
-         pmlbn(i,1) = mu*myhx(i,1,1,1)
-         pmlbn(i,2) = mu*myhy(i,1,1,1)
-         pmlbn(i,3) = mu*myhz(i,1,1,1)
-         pmldn(i,1) = eps*myex(i,1,1,1)
-         pmldn(i,2) = eps*myey(i,1,1,1)
-         pmldn(i,3) = eps*myez(i,1,1,1)
+         pmlbn(i,1) = mu*hx(i)
+         pmlbn(i,2) = mu*hy(i)
+         pmlbn(i,3) = mu*hz(i)
+         pmldn(i,1) = eps*ex(i)
+         pmldn(i,2) = eps*ey(i)
+         pmldn(i,3) = eps*ez(i)
       enddo
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -89,12 +88,8 @@ c-----------------------------------------------------------------------
       real omega,eps1,eps2,mu1,mu2,reflte,trante,refltm,trantm
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       integer e,i,j,k,l,lx1_2
       real ky,uu
@@ -123,10 +118,10 @@ c     Global number
                         pmlfac = 0.0
                      endif
                      uu = exp(-eta*pmlfac)*cos(ky*yy-omega*tt)
-                     myshz(i,j,k,e) = reflte*uu
-                     mysex(i,j,k,e) = -eta*reflte*uu
-                     mysez(i,j,k,e) = refltm*uu
-                     myshx(i,j,k,e) = refltm*uu/eta
+                     solhz(l) = reflte*uu
+                     solex(l) = -eta*reflte*uu
+                     solez(l) = refltm*uu
+                     solhx(l) = refltm*uu/eta
                   else
                      if (pmltag(e).ne.0) then
                         d = pmlinner(3)-pmlouter(3)
@@ -138,10 +133,10 @@ c     Global number
                         pmlfac = 0.0
                      endif
                      uu = exp(-eta*pmlfac)*cos(-ky*yy-omega*tt)
-                     myshz(i,j,k,e) = trante*uu
-                     mysex(i,j,k,e) = eta*trante*uu
-                     mysez(i,j,k,e) = trantm*uu
-                     myshx(i,j,k,e) = -trantm*uu/eta
+                     solhz(l) = trante*uu
+                     solex(l) = eta*trante*uu
+                     solez(l) = trantm*uu
+                     solhx(l) = -trantm*uu/eta
                   endif
                enddo
             enddo
@@ -151,13 +146,14 @@ c     Global number
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -285,6 +281,8 @@ c     k is the volume global number associated with face j.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
+
       return
       end
 c-----------------------------------------------------------------------

--- a/tests/cylwave/cylwave.usr
+++ b/tests/cylwave/cylwave.usr
@@ -3,12 +3,19 @@ c
 c     Cylindrical waveguide.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
 c     See David de Wolf, Essentials of Electromagnetics for Engineering,
 c     Cambridge University Press, 2001 Section 19.7. This is the TM wave
@@ -19,12 +26,8 @@ c     case.
       include 'EMWAVE'
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       real cspeed
       parameter (cspeed = 1.0)
@@ -144,12 +147,12 @@ c     Compute solution
      $           *bssljp(m,bigk*rho)*cos(m*phi))
             hzz = 0.0           ! TM case
 
-            myshx(i,1,1,1) = cos(phi)*hrho-sin(phi)*hphi
-            myshy(i,1,1,1) = sin(phi)*hrho+cos(phi)*hphi
-            myshz(i,1,1,1) = hzz
-            mysex(i,1,1,1) = cos(phi)*erho-sin(phi)*ephi
-            mysey(i,1,1,1) = sin(phi)*erho+cos(phi)*ephi
-            mysez(i,1,1,1) = ezz
+            solhx(i) = cos(phi)*hrho-sin(phi)*hphi
+            solhy(i) = sin(phi)*hrho+cos(phi)*hphi
+            solhz(i) = hzz
+            solex(i) = cos(phi)*erho-sin(phi)*ephi
+            soley(i) = sin(phi)*erho+cos(phi)*ephi
+            solez(i) = ezz
          endif
       enddo
 
@@ -230,31 +233,28 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt, myhx, myhy, myhz, myex, myey, myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
-      include 'EMWAVE'
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
+      implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -271,7 +271,7 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine uservp (ix,iy,iz,ieg)
+      subroutine uservp(ix,iy,iz,ieg)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'

--- a/tests/drude/drude.usr
+++ b/tests/drude/drude.usr
@@ -4,13 +4,12 @@ c     Normally-incident plane wave striking a dielectric Drude-material
 c     interface.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
-      include 'RK5'
 
       common /userparam/ omega,eps1,eps2,mu1,mu2,mydrudea,mydrudeb,ceps2
      $     ,refl,tran
@@ -20,11 +19,14 @@ c-----------------------------------------------------------------------
       common /userincvars/ incindex,ninc
       integer incindex(lxzfl),ninc
 
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
       integer i,j,k
       real ky
-      real yy,tt,mu,eps,eta,uinc
+      real yy,mu,eps,eta,uinc
 
-      tt = rktime
       do i = 1,ninc
          j = incindex(i)
          k = cemface(j)
@@ -34,14 +36,14 @@ c-----------------------------------------------------------------------
          eta = sqrt(mu/eps)
          ky = omega*sqrt(mu*eps)
          uinc = cos(-ky*yy-omega*tt)
-         fHN(j,3) = fHN(j,3)+uinc
-         fEN(j,1) = fEN(j,1)+eta*uinc
+         incfhz(j) = incfhz(j)+uinc
+         incfex(j) = incfex(j)+eta*uinc
       enddo
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -60,29 +62,25 @@ c-----------------------------------------------------------------------
       complex ceps2,refl,tran
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
       integer i,j
       real mu,eps,yy
       complex sigmadrude,ky,efac,eta,CI
       parameter (CI = (0.0,1.0))
 
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 c     We need to set the extra PML fields too
       do i = 1,npts
          mu = permeability(i)
          eps = permittivity(i)
-         pmlbn(i,1) = mu*myhx(i,1,1,1)
-         pmlbn(i,2) = mu*myhy(i,1,1,1)
-         pmlbn(i,3) = mu*myhz(i,1,1,1)
-         pmldn(i,1) = eps*myex(i,1,1,1)
-         pmldn(i,2) = eps*myey(i,1,1,1)
-         pmldn(i,3) = eps*myez(i,1,1,1)
+         pmlbn(i,1) = mu*hx(i)
+         pmlbn(i,2) = mu*hy(i)
+         pmlbn(i,3) = mu*hz(i)
+         pmldn(i,1) = eps*ex(i)
+         pmldn(i,2) = eps*ey(i)
+         pmldn(i,3) = eps*ez(i)
       enddo
 
 c     Initialize the current
@@ -100,7 +98,7 @@ c     Initialize the current
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -114,12 +112,8 @@ c-----------------------------------------------------------------------
       complex ceps2,refl,tran
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       integer e,i,j,l,lx1_2
       real yy,d,pmlfac,pmlsigmamax
@@ -146,14 +140,14 @@ c     Global number
                      pmlfac = 0.0
                   endif
                   usc = refl*cexp(CI*(ky*yy-omega*tt)-eta*pmlfac)
-                  myshz(i,j,1,e) = dble(usc)
-                  mysex(i,j,1,e) = dble(-eta*usc)
+                  solhz(l) = dble(usc)
+                  solex(l) = dble(-eta*usc)
                else
                   eta = csqrt(mu2/ceps2)
                   ky = omega*csqrt(ceps2*mu2)
                   usc = tran*cexp(CI*(-ky*yy-omega*tt))
-                  myshz(i,j,1,e) = dble(usc)
-                  mysex(i,j,1,e) = dble(eta*usc)
+                  solhz(l) = dble(usc)
+                  solex(l) = dble(eta*usc)
                endif
             enddo
          enddo
@@ -162,7 +156,7 @@ c     Global number
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -173,7 +167,8 @@ c-----------------------------------------------------------------------
       real jn,kjn,resjn,drudeparams
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       call cem_maxwell_drude(jn,kjn,resjn,drudeparams,drudeindex,ndrude)
 

--- a/tests/graphene/graphene.usr
+++ b/tests/graphene/graphene.usr
@@ -3,7 +3,7 @@ c
 c     Normally-incident plane wave striking a flat sheet of graphene.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
 c     Use this subroutine to compute the incident field.
       implicit none
@@ -19,9 +19,13 @@ c     Use this subroutine to compute the incident field.
       common /userincvars/ incindex,ninc
       integer incindex(lxzfl),ninc
 
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
       integer i,j,k
       real ky
-      real yy,tt,mu,eps,eta,uinc
+      real yy,mu,eps,eta,uinc
       complex CI
       parameter (CI = (0.0,1.0))
 
@@ -35,14 +39,14 @@ c     Use this subroutine to compute the incident field.
          eta = sqrt(mu/eps)
          ky = omega*sqrt(mu*eps)
          uinc = dble(cexp(CI*(-ky*yy-omega*tt)))
-         fHN(j,3) = fHN(j,3)+uinc
-         fEN(j,1) = fEN(j,1)+eta*uinc
+         incfhz(j) = incfhz(j)+uinc
+         incfex(j) = incfex(j)+eta*uinc
       enddo
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -59,31 +63,28 @@ c-----------------------------------------------------------------------
       real fjn,kfjn,resfjn,graphparams
       integer graphindex,ngraph
 
-      integer i,j,k
-      real tt,yy
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real tt
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
+      integer i,j,k
+      real yy
       real a_d,b_d,b_cp1,a_211,a_221,b_11,b_21,b_cp2,a_212,a_222,b_12
      $     ,b_22
       complex z1,cfqn2,cfpn2,cfqn3,cfpn3,enpar,CI
       parameter (CI = (0.0,1.0))
 
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 c     We need to set the extra PML fields too
       do i = 1,npts
          mu = permeability(i)
          eps = permittivity(i)
-         pmlbn(i,1) = mu*myhx(i,1,1,1)
-         pmlbn(i,2) = mu*myhy(i,1,1,1)
-         pmlbn(i,3) = mu*myhz(i,1,1,1)
-         pmldn(i,1) = eps*myex(i,1,1,1)
-         pmldn(i,2) = eps*myey(i,1,1,1)
-         pmldn(i,3) = eps*myez(i,1,1,1)
+         pmlbn(i,1) = mu*hx(i)
+         pmlbn(i,2) = mu*hy(i)
+         pmlbn(i,3) = mu*hz(i)
+         pmldn(i,1) = eps*ex(i)
+         pmldn(i,2) = eps*ey(i)
+         pmldn(i,3) = eps*ez(i)
       enddo
 
 c     We also have to initialize all of the currents
@@ -121,7 +122,7 @@ c     form)
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -134,12 +135,8 @@ c-----------------------------------------------------------------------
       complex sigmagraph,refl,tran
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       integer e,i,j,l,lx1_2
       real ky
@@ -168,9 +165,9 @@ c     Global number
                   else
                      pmlfac = 0.0
                   endif
-                  myshz(i,j,1,e) =
+                  solhz(l) =
      $                 dble(refl*cexp(CI*(ky*yy-omega*tt)-eta*pmlfac))
-                  mysex(i,j,1,e) = -eta*myshz(i,j,1,e)
+                  solex(l) = -eta*solhz(l)
                else
                   if (pmltag(e).ne.0) then
                      d = pmlinner(3)-pmlouter(3)
@@ -181,9 +178,9 @@ c     Global number
                   else
                      pmlfac = 0.0
                   endif
-                  myshz(i,j,1,e) =
+                  solhz(l) =
      $                 dble(tran*cexp(CI*(-ky*yy-omega*tt)-eta*pmlfac))
-                  mysex(i,j,1,e) = eta*myshz(i,j,1,e)
+                  solex(l) = eta*solhz(l)
                endif
             enddo
          enddo
@@ -192,13 +189,14 @@ c     Global number
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       return
       end
@@ -476,10 +474,10 @@ c-----------------------------------------------------------------------
 
          call userprint(istep,time,dt,l2,linf,cpu_t,cpu_p_t)
 
-c$$$         do i = 1,6
-c$$$            if (l2(i).gt.l2tol(i)) stop 1
-c$$$            if (linf(i).gt.linftol(i)) stop 1
-c$$$         enddo
+         do i = 1,6
+            if (l2(i).gt.l2tol(i)) stop 1
+            if (linf(i).gt.linftol(i)) stop 1
+         enddo
       endif
 
       return

--- a/tests/lorentz/lorentz.usr
+++ b/tests/lorentz/lorentz.usr
@@ -4,7 +4,7 @@ c     Normally-incident plane wave striking a dielectric
 c     Lorentz-material interface.
 c
 c-----------------------------------------------------------------------
-      subroutine userinc
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -20,9 +20,13 @@ c-----------------------------------------------------------------------
       common /userincvars/ incindex,ninc
       integer incindex(lxzfl),ninc
 
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
       integer i,j,k
       real ky
-      real yy,tt,mu,eps,eta,uinc
+      real yy,mu,eps,eta,uinc
 
       tt = rktime
       do i = 1,ninc
@@ -34,14 +38,14 @@ c-----------------------------------------------------------------------
          eta = sqrt(mu/eps)
          ky = omega*sqrt(mu*eps)
          uinc = cos(-ky*yy-omega*tt)
-         fHN(j,3) = fHN(j,3)+uinc
-         fEN(j,1) = fEN(j,1)+eta*uinc
+         incfhz(j) = incfhz(j)+uinc
+         incfex(j) = incfex(j)+eta*uinc
       enddo
 
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt,myhx,myhy,myhz,myex,myey,myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -60,12 +64,8 @@ c-----------------------------------------------------------------------
       complex ceps2,refl,tran
 
       real tt
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
       integer i,j
       real mu,eps,yy
@@ -73,17 +73,17 @@ c-----------------------------------------------------------------------
       complex sigmaloren,ky,efac,eta,jnfac,CI
       parameter (CI = (0.0,1.0))
 
-      call usersol(tt,myhx,myhy,myhz,myex,myey,myez)
+      call usersol(tt,hx,hy,hz,ex,ey,ez)
 c     We need to set the extra PML fields too
       do i = 1,npts
          mu = permeability(i)
          eps = permittivity(i)
-         pmlbn(i,1) = mu*myhx(i,1,1,1)
-         pmlbn(i,2) = mu*myhy(i,1,1,1)
-         pmlbn(i,3) = mu*myhz(i,1,1,1)
-         pmldn(i,1) = eps*myex(i,1,1,1)
-         pmldn(i,2) = eps*myey(i,1,1,1)
-         pmldn(i,3) = eps*myez(i,1,1,1)
+         pmlbn(i,1) = mu*hx(i)
+         pmlbn(i,2) = mu*hy(i)
+         pmlbn(i,3) = mu*hz(i)
+         pmldn(i,1) = eps*ex(i)
+         pmldn(i,2) = eps*ey(i)
+         pmldn(i,3) = eps*ez(i)
       enddo
 
 c     Initialize the current
@@ -106,7 +106,7 @@ c     Initialize the current
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt,myshx,myshy,myshz,mysex,mysey,mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -120,14 +120,10 @@ c-----------------------------------------------------------------------
       complex ceps2,refl,tran
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
-      integer e,i,j,lx1_2
+      integer e,i,j,l,lx1_2
       real yy,d,pmlfac,pmlsigmamax
       complex ky,eta,usc,CI
       parameter (CI = (0.0,1.0))
@@ -137,6 +133,7 @@ c-----------------------------------------------------------------------
          do j = 1,ly1
             do i = 1,lx1
 c     Global number
+               l = i+nx1*(j-1)+nx1*ny1*(e-1)
                yy = ym1(i,j,1,e)
                if (ym1(lx1_2,lx1_2,1,e).gt.0.0) then
                   eta = sqrt(mu1/eps1)
@@ -151,14 +148,14 @@ c     Global number
                      pmlfac = 0.0
                   endif
                   usc = refl*cexp(CI*(ky*yy-omega*tt)-eta*pmlfac)
-                  myshz(i,j,1,e) = dble(usc)
-                  mysex(i,j,1,e) = dble(-eta*usc)
+                  solhz(l) = dble(usc)
+                  solex(l) = dble(-eta*usc)
                else
                   eta = csqrt(mu2/ceps2)
                   ky = omega*csqrt(ceps2*mu2)
                   usc = tran*cexp(CI*(-ky*yy-omega*tt))
-                  myshz(i,j,1,e) = dble(usc)
-                  mysex(i,j,1,e) = dble(eta*usc)
+                  solhz(l) = dble(usc)
+                  solex(l) = dble(eta*usc)
                endif
             enddo
          enddo
@@ -167,7 +164,7 @@ c     Global number
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersrc(tt,srchn,srcen)
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
 c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -178,7 +175,8 @@ c-----------------------------------------------------------------------
       real jn,kjn,resjn,lorentzparams
 
       real tt
-      real srchn(lpts,3),srcen(lpts,3)
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
 
       call cem_maxwell_lorentz(jn,kjn,resjn,lorentzparams,lorentzindex
      $     ,nlorentz)
@@ -286,6 +284,7 @@ c     k is the volume global number associated with face j.
 c-----------------------------------------------------------------------
       subroutine usrdat
 c-----------------------------------------------------------------------
+      implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'


### PR DESCRIPTION
Now they all pass in the x, y, and z components of the H and E fields
separately. This is preferred over passing the components together
since it is impossible to do this in `userfsrc` due to how `srflx` is
structured.