### PR TITLE
Split up the initialization of the PML

### DIFF
--- a/src/EMWAVE
+++ b/src/EMWAVE
@@ -26,9 +26,8 @@ c=======================================================================
      $     ,ifprecon,ifgfdmdd,ifsemg,iffdm
 
       common /cemfce1/
-     $     cemface(2*ldim*lx1*lz1*lelt),
-     $     cemface_alt(2*ldim*lx1*lz1*lelt)
-      real cemface,cemface_alt
+     $     cemface(2*ldim*lx1*lz1*lelt)
+      real cemface
 
       common /cemfce2/
      $     ncemface             ! number of points on the faces

--- a/src/cem_common.F
+++ b/src/cem_common.F
@@ -308,52 +308,6 @@ C Used in GPU calculation
       return
       end
 c-----------------------------------------------------------------------
-      subroutine cem_alternate_flux_ptr
-c
-c     Set up pointer to restrict u to faces ! NOTE: compact
-c
-      implicit none
-      include 'SIZE'
-      include 'TOTAL'
-      include 'EMWAVE'
-c
-      integer k,l,i,e,f,ef,js1,jf1,jskip1,js2,jf2,jskip2,j1,j2
-      integer k_opp, ef_opp
-
-      if (nid.eq.0) then
-          write(6,*) 'start: cem_alternatve_flux_ptr-> index setting'
-      endif
-
-      k = 0
-      l = 0
-      do e = 1,nelt
-      do f = 1,nfaces,2
-         ef    = eface(f  )
-         ef_opp= eface(f+1) ! opposite
-         do i=1,nxzf
-            k     = i+nxzf*(ef-1)    +nxzf*nfaces*(e-1)   ! face   numbering
-            k_opp = i+nxzf*(ef_opp-1)+nxzf*nfaces*(e-1)   ! face   numbering
-            cemface_alt(k_opp)= cemface(k    )
-            cemface_alt(k    )= cemface(k_opp)
-c           write(6,*) 'k/k_opp',k_opp,cemface_alt(k_opp)
-c    $                          ,k,cemface_alt(k)
-         enddo
-
-      enddo
-      enddo
-
-c     do i=1,ncemface
-c        write(6,*) 'cemface/cemface_alt',i,cemface(i),cemface_alt(i)
-c     enddo
-
-      if (nid.eq.0) then
-         write(6,*) 'done: cem_alternate_flux_ptr'
-      endif
-
-
-      return
-      end
-c-----------------------------------------------------------------------
       subroutine measure_time(name8,ireset,t0,time_sum,iprint)
 c-----------------------------------------------------------------------
       implicit none

--- a/src/cem_maxwell.F
+++ b/src/cem_maxwell.F
@@ -160,12 +160,18 @@ c     pml related arrays
       enddo
       if (nid.eq.0) write(6,*) 'done: initialization geom/fields'
 
-c     Get global numbering on face and set material properties
       call cem_set_fc_ptr       ! global numbering index on face
+      if (ifpml) then
+         call pml_errchk
+         call pml_fill_faceary(faceary,pmlthick)
+         call pml_extent_and_tags(pmlinner,pmlouter,pmltag,faceary)
+      endif
       call cem_maxwell_uvp      ! returns material properties
       call cem_maxwell_materials ! other material related settings
-      call cem_alternate_flux_ptr
-      if (ifpml) call pml_setup
+      if (ifpml) then
+         call pml_calc_sigma(pmlinner,pmlouter,pmltag,pmlorder,
+     $                       pmlreferr)
+      endif
 
 c     Communication routines
       call cem_communication_cost_check

--- a/src/cem_maxwell_pml.F
+++ b/src/cem_maxwell_pml.F
@@ -1,5 +1,6 @@
 c-----------------------------------------------------------------------
-      subroutine pml_setup
+      subroutine pml_errchk
+c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
@@ -11,7 +12,7 @@ c-----------------------------------------------------------------------
 c     How much of the incident signal is permitted to be reflected
 c     by the PML. See the term R(0) in formula (7.57) of the Taflove
 c     book.
-      pmlreferr= param(79)
+      pmlreferr = param(79)
 
       if ((pmlthick.lt.1).or.(pmlthick.gt.10)) then
         write (*,*) 'Something is wrong with your pmlthick setting'
@@ -32,31 +33,8 @@ c     book.
         call exitt(1)
       endif
 
-      call pml_fill_faceary (faceary,pmlthick)
-      call pml_extent_and_tags (pmlinner,pmlouter,pmltag,faceary)
-      call pml_calc_sigma (pmlinner,pmlouter,pmltag,pmlorder,pmlreferr)
-c     call pml_faces (faceary)
-      call pml_zero_fields
-
       return
       end
-c-----------------------------------------------------------------------
-      subroutine pml_zero_fields
-      implicit none
-      include 'SIZE'
-      include 'TOTAL'
-      include 'PML'
-
-      integer n3
-
-      n3 = lx1*ly1*lz1*lelt*3
-
-      call rzero(pmlbn,n3)
-      call rzero(pmldn,n3)
-
-      return
-      end
-
 c-----------------------------------------------------------------------
       subroutine pml_faces(farray)
       implicit none


### PR DESCRIPTION
There are two parts to seting up the PML: figuring out where it is and
setting its material parameters. Previously those were both done
back-to-back and before `uservp` was called. However, sometimes a user
might need to know where the PML is when setting material parameters
(e.g. when determining the location of a sheet of graphene). This
splits the PML setup into two parts and calls `uservp` in the middle
to make this use-case possible.