### PR TITLE
Use CFL condition instead of exact timestep in `graphene`

### DIFF
--- a/tests/2dgraphene/2dgraphene.rea
+++ b/tests/2dgraphene/2dgraphene.rea
@@ -13,7 +13,7 @@
   0                             9: ---
   0.0                           10: fintim: final time if positive; overrides nsteps. Ignored if negative.
   1000                          11: nsteps: total number of timesteps
-  -0.005                        12: dt: timestep size if negative, eg. -0.05; CFL number if positive, eg. CFL = 0.2
+  0.2                           12: dt: timestep size if negative, eg. -0.05; CFL number if positive, eg. CFL = 0.2
   100                           13: iocomm: frequency of print statements
   0.000000E+00                  14: ---
   10                            15: iostep: frequency of vtk writes


### PR DESCRIPTION
So that everything doesn't blow up when higher orders are used.