### PR TITLE
Speed up the PML on the GPU

### DIFF
--- a/bin/arch.json
+++ b/bin/arch.json
@@ -67,12 +67,12 @@
     "tesla-pgi-acc": {
         "FC": "mpif90",
 	"FFLAGS": ["-I.", "-acc", "-Minfo=accel",
-	           "-ta=nvidia:cc50,cc60", "-DMPIIO", "-O3", "-r8"],
+	           "-ta=tesla:cc50,cuda8.0", "-DMPIIO", "-O3", "-r8"],
 	"CC": "mpicc",
 	"CFLAGS": ["-I.", "-acc", "-Minfo=accel",
-	           "-ta=nvidia:cc50,cc60", "-DMPIIO", "-O3", "-DMPI",
+	           "-ta=tesla:cc50,cuda8.0", "-DMPIIO", "-O3", "-DMPI",
 		   "-DUNDERSCORE", "-DGLOBAL_LONG_LONG"],
         "LD": "mpif90",
-        "LDFLAGS": ["-lblas", "-llapack", "-ta=nvidia:cc50,cc60"]
+        "LDFLAGS": ["-lblas", "-llapack", "-ta=tesla:cc50,cuda8.0"]
     }
 }

--- a/src/cem_maxwell_pml.F
+++ b/src/cem_maxwell_pml.F
@@ -533,11 +533,10 @@ c     cases.
 !$ACC DATA PRESENT(pmlptr,bm1,pmlsigma,permittivity,permeability)
 !$ACC&     PRESENT(reshn,resen,hn,en)
 !$ACC&     PRESENT(respmlhn,respmlen,respmlbn,respmldn,pmlbn,pmldn)
-
-
-!$ACC KERNELS
+!$ACC PARALLEL LOOP GANG INDEPENDENT
       do ie = 1,maxpml
          e = pmlptr(ie)
+!$ACC LOOP VECTOR INDEPENDENT
          do i = 1,nxyz
             j = i+nxyz*(e-1)
 
@@ -589,8 +588,7 @@ c     cases.
             resen(j,3) = resen(j,3)+respmlen(j,3)*bm1(i,1,1,e)
          enddo
       enddo
-!$ACC END KERNELS
-
+!$ACC END PARALLEL LOOP
 !$ACC END DATA
 
       return

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -37,15 +37,7 @@
 	"usr": "2dboxpml",
 	"rea": "2dboxpml",
 	"params": {"4": 1, "11": 4000},
-	"parallelization": ["mpi"]
-    },
-    "2dboxpml-te-acc": {
-	"app": "maxwell",
-	"dir": "2dboxpml",
-	"usr": "2dboxpml",
-	"rea": "2dboxpml",
-	"params": {"4": 1, "11": 100},
-	"parallelization": ["acc"]
+	"parallelization": ["mpi", "acc"]
     },
     "2dboxpml-tm": {
 	"app": "maxwell",
@@ -53,15 +45,7 @@
 	"usr": "2dboxpml",
 	"rea": "2dboxpml",
 	"params": {"4": 2, "11": 4000},
-	"parallelization": ["mpi"]
-    },
-    "2dboxpml-tm-acc": {
-	"app": "maxwell",
-	"dir": "2dboxpml",
-	"usr": "2dboxpml",
-	"rea": "2dboxpml",
-	"params": {"4": 2, "11": 100},
-	"parallelization": ["acc"]
+	"parallelization": ["mpi", "acc"]
     },
     "2ddielectric-te-1mat": {
 	"app": "maxwell",


### PR DESCRIPTION
Force the loop in PML step to run in parallel; this gives about a 10x
speedup. After these changes the hottest spot is now
`cem_maxwell_add_flux_to_res`.