### PR TITLE
Make `cem_maxwell_add_flux_to_res` run in parallel

### DIFF
--- a/src/EMWAVE
+++ b/src/EMWAVE
@@ -27,7 +27,7 @@ c=======================================================================
 
       common /cemfce1/
      $     cemface(2*ldim*lx1*lz1*lelt)
-      real cemface
+      integer cemface
 
       common /cemfce2/
      $     ncemface             ! number of points on the faces

--- a/src/cem_common.F
+++ b/src/cem_common.F
@@ -212,82 +212,72 @@ c
       end
 c-----------------------------------------------------------------------
       subroutine cem_set_fc_ptr
-c
-c     Set up pointer to restrict u to faces ! NOTE: compact
-c
-c      implicit none
+c-----------------------------------------------------------------------
+c     Set up pointer to restrict fields to faces.
+      implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
-c
-      integer k,l,i,e,f,ef,js1,jf1,jskip1,js2,jf2,jskip2,j1,j2
 
-c... <<< below is used for openacc
-      integer p
+      common /cemfce_acc/
+     $     cemface2(2*ldim*lx1*lz1*lelt),
+     $     cemface_ptr(0:2*ldim*lx1*lz1*lelt),
+     $     cemface_ind(2*ldim*lx1*lz1*lelt)
+      integer cemface2,cemface_ptr,cemface_ind
 
-      COMMON /cemfce_acc/ cemface2(2*ldim*lx1*lz1*lelt)
-     $     ,              cemface_ptr(0:2*ldim*lx1*lz1*lelt)
-     $     ,              cemface_ind(2*ldim*lx1*lz1*lelt)
-      integer cemface2, cemface_ptr, cemface_ind
-c... >>>
+      integer k,l,i,e,f,ef,js1,jf1,jskip1,js2,jf2,jskip2,j1,j2,p
 
       if (nid.eq.0) then
-
          write(6,*) 'start: cem_set_fc_ptr, volume index j=cemface(i)'
       endif
 
       k = 0
       l = 0
-      do e=1,nelt
-      do f=1,nfaces
+      do e = 1,nelt
+         do f = 1,nfaces
+            ef = eface(f)
+            js1 = skpdat(1,f)
+            jf1 = skpdat(2,f)
+            jskip1 = skpdat(3,f)
+            js2 = skpdat(4,f)
+            jf2 = skpdat(5,f)
+            jskip2 = skpdat(6,f)
 
-         ef     = eface(f)
-         js1    = skpdat(1,f)
-         jf1    = skpdat(2,f)
-         jskip1 = skpdat(3,f)
-         js2    = skpdat(4,f)
-         jf2    = skpdat(5,f)
-         jskip2 = skpdat(6,f)
-
-         i = 0
-         do j2=js2,jf2,jskip2
-         do j1=js1,jf1,jskip1
-
-            i = i+1
-            l = l+1
-            k = i+nxzf*(ef-1)+nxzf*nfaces*(e-1)           ! face   numbering
-            cemface(k) = j1+nx1*(j2-1)+nxyz*(e-1) ! global numbering
-            ncemface   = l
-            !write(6,*) 'fc',ncemface,e,k,f,ef!,srfout(k)!glo_num3d(cemface(k))
-            ! glo_num(cemface(k))  get global numbering
-            ! cemface gets the Ed's numbering at faces following pff order
-
+            i = 0
+            do j2 = js2,jf2,jskip2
+               do j1 = js1,jf1,jskip1
+                  i = i+1
+                  l = l+1
+c     Face numbering.
+                  k = i+nxzf*(ef-1)+nxzf*nfaces*(e-1)
+c     Global number; `cemface` gets Ed's numbering at faces following
+c     pff order.
+                  cemface(k) = j1+nx1*(j2-1)+nxyz*(e-1)
+               enddo
+            enddo
+            ncemface = l
          enddo
-         enddo
-
-      enddo
       enddo
 
-c... used for openacc
+#ifdef _OPENACC
       call icopy(cemface_ind,cemface,ncemface)
       call isort(cemface_ind,cemface2,ncemface)
 
-C Used in GPU calculation
       p = 1
       cemface_ptr(1) = cemface_ind(1)
-      do i=2,ncemface
-         if (cemface_ind(i) .ne. cemface_ind(i-1)) then
+      do i = 2,ncemface
+         if (cemface_ind(i).ne.cemface_ind(i-1)) then
             p = p+1
             cemface_ptr(p) = i
          endif
       enddo
       cemface_ptr(p+1) = ncemface+1
       cemface_ptr(0) = p
+#endif
 
       if (nid.eq.0) then
          write(6,*) 'done: cem_set_fc_ptr, ncemface= ',ncemface
       endif
-
 
       return
       end

--- a/src/cem_maxwell.F
+++ b/src/cem_maxwell.F
@@ -605,7 +605,6 @@ c     restrict u to faces
       include 'TOTAL'
       include 'EMWAVE'
 
-
 !$ACC DATA PRESENT (fHN,fEN,HN,EN,cemface)
       if (imode.eq.3) then
 !$ACC PARALLEL LOOP INDEPENDENT
@@ -650,21 +649,78 @@ c     restrict u to faces
       end
 c-----------------------------------------------------------------------
       subroutine cem_maxwell_add_flux_to_res(srflx)
+c-----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
-      integer  i,j,k
-      real     srflx(6*2*ldim*lx1*lz1*lelt)
-      real     a
+
+      common /cemfce_acc/
+     $     cemface2(2*ldim*lx1*lz1*lelt),
+     $     cemface_ptr(0:2*ldim*lx1*lz1*lelt),
+     $     cemface_ind(2*ldim*lx1*lz1*lelt)
+      integer cemface2,cemface_ptr,cemface_ind
+
+      real srflx(6*2*ldim*lx1*lz1*lelt)
+
+      integer i,j,k
+#ifdef _OPENACC
+      integer l,p,nptr
+#endif
+      real a
 
       k = nxzfl
-
-!$ACC DATA PRESENT(cemface,aream,srflx,reshn,resen)
-      if     (imode.eq.3) then !IF3D
-
-!$ACC KERNELS
-         do j=  1,ncemface
+#ifdef _OPENACC
+      nptr = cemface_ptr(0)
+!$ACC DATA PRESENT(resHN,resEN,aream,srflx,cemface2,cemface_ptr,
+!$ACC&             cemface_ind)
+      if (imode.eq.3) then      ! 3D
+!$ACC PARALLEL LOOP
+         do p = 1,nptr
+!$ACC LOOP SEQ
+            do l = cemface_ptr(p),cemface_ptr(p+1)-1
+               i = cemface_ind(l)
+               j = cemface2(l)
+               a = aream(j)
+               resHN(i,1) = resHN(i,1) + a*srflx(0*k+j)
+               resHN(i,2) = resHN(i,2) + a*srflx(1*k+j)
+               resHN(i,3) = resHN(i,3) + a*srflx(2*k+j)
+               resEN(i,1) = resEN(i,1) + a*srflx(3*k+j)
+               resEN(i,2) = resEN(i,2) + a*srflx(4*k+j)
+               resEN(i,3) = resEN(i,3) + a*srflx(5*k+j)
+            enddo
+         enddo
+      elseif (imode.eq.2) then  ! TM
+!$ACC PARALLEL LOOP
+         do p = 1,nptr
+!$ACC LOOP SEQ
+            do l = cemface_ptr(p),cemface_ptr(p+1)-1
+               i = cemface_ind(l)
+               j = cemface2(l)
+               a = aream(j)
+               resHN(i,1) = resHN(i,1) + a*srflx(0*k+j)
+               resHN(i,2) = resHN(i,2) + a*srflx(1*k+j)
+               resEN(i,3) = resEN(i,3) + a*srflx(2*k+j)
+            enddo
+         enddo
+      elseif (imode.eq.1) then  ! TE
+!$ACC PARALLEL LOOP
+         do p = 1,nptr
+!$ACC LOOP SEQ
+            do l = cemface_ptr(p),cemface_ptr(p+1)-1
+               i = cemface_ind(l)
+               j = cemface2(l)
+               a = aream(j)
+               resEN(i,1) = resEN(i,1) + a*srflx(0*k+j)
+               resEN(i,2) = resEN(i,2) + a*srflx(1*k+j)
+               resHN(i,3) = resHN(i,3) + a*srflx(2*k+j)
+            enddo
+         enddo
+      endif
+!$ACC END DATA
+#else
+      if (imode.eq.3) then  ! 3D
+         do j = 1,ncemface
             i = cemface(j)
             a = aream(j)
             resHN(i,1) = resHN(i,1) + a*srflx(0*k+j)
@@ -674,20 +730,15 @@ c-----------------------------------------------------------------------
             resEN(i,2) = resEN(i,2) + a*srflx(4*k+j)
             resEN(i,3) = resEN(i,3) + a*srflx(5*k+j)
          enddo
-!$ACC END KERNELS
-
-      elseif (imode.eq.2) then  !IFTM
-!$ACC KERNELS
-         do j=  1,ncemface
+      elseif (imode.eq.2) then  ! TM
+         do j = 1,ncemface
             i = cemface(j)
             a = aream(j)
             resHN(i,1) = resHN(i,1) + a*srflx(0*k+j)
             resHN(i,2) = resHN(i,2) + a*srflx(1*k+j)
             resEN(i,3) = resEN(i,3) + a*srflx(2*k+j)
          enddo
-!$ACC END KERNELS
-      elseif (imode.eq.1) then  !IFTE
-!$ACC KERNELS
+      elseif (imode.eq.1) then  ! TE
          do j = 1,ncemface
             i = cemface(j)
             a = aream(j)
@@ -695,9 +746,8 @@ c-----------------------------------------------------------------------
             resEN(i,2) = resEN(i,2) + a*srflx(1*k+j)
             resHN(i,3) = resHN(i,3) + a*srflx(2*k+j)
          enddo
-!$ACC END KERNELS
       endif
-!$ACC END DATA
+#endif
 
       return
       end


### PR DESCRIPTION
The previous kernels directive was not enough to force
parallelization. This restores the loops from
`cem_maxwell_add_flux_to_res_acc` in SVN 1698. A bug where `cemface`
is declared as a real array is also fixed.