### PR TITLE
Merge the `3dboxpml` and `3dboxpml-acc` tests

### DIFF
--- a/tests/tests.json
+++ b/tests/tests.json
@@ -157,15 +157,7 @@
 	"usr": "3dboxpml",
 	"rea": "3dboxpml",
 	"params": {"11": 2000},
-	"parallelization": ["mpi"]
-    },
-    "3dboxpml-acc": {
-	"app": "maxwell",
-	"dir": "3dboxpml",
-	"usr": "3dboxpml",
-	"rea": "3dboxpml",
-	"params": {"11": 50},
-	"parallelization": ["acc"]
+	"parallelization": ["mpi", "acc"]
     },
     "3ddielectric-1mat": {
 	"app": "maxwell",


### PR DESCRIPTION
Previously the OpenACC version of the test ran for less steps because
it was very slow, but due to recent speed ups that is no longer
necessary.