### PR TITLE
Fix segfault in `io_co.c`

### DIFF
--- a/src/io_co.c
+++ b/src/io_co.c
@@ -90,7 +90,8 @@ void openfile4_(  int *id, int *nid)
 		fflush(stdout);
 	}
 
-	mfBuffer = (char*) malloc( sizeof( char) * 4 * ONE_MILLION);
+	mfBuffer = (char*) malloc( sizeof( char) * 8 * ONE_MILLION);
+        assert(mfBuffer != NULL);
 	mfBufferCur = 0;
 #endif
 }


### PR DESCRIPTION
Note that long-term a better fix is probably still needed here.

Ping @misunmin @abishekvenkit this fixes the segfault we were seeing with the cylinder mesh today.