### PR TITLE
Add dependency on SIZE in the makefile

### DIFF
--- a/bin/Makefile.inc
+++ b/bin/Makefile.inc
@@ -32,7 +32,7 @@ JLOBJ = $(patsubst $(JLBASE)/%.c, obj/%.o, $(JLSRC))
 USROBJ = obj/subuser.o
 
 
-obj/%.o : $(NEKBASE)/%.F
+obj/%.o : $(NEKBASE)/%.F SIZE
 	$(FC) -c $(FFLAGS) $< -o $@
 
 obj/%.o : $(NEKBASE)/%.c


### PR DESCRIPTION
As a result it is no longer necessary to run `make clean` before
recompiling if the SIZE file is changed.