### PR TITLE
Add first acoustic solver test

### DIFF
--- a/src/cem_acoustic.F
+++ b/src/cem_acoustic.F
@@ -5133,8 +5133,7 @@ c......
                tmp1        = 2*p*pi/length
                z_alphap(ip)= tmp1
                z_betap (ip)= z_kw(idir)**2-(z_alpha0(e)+z_alphap(ip))**2
-               z_betap (ip)= sqrt(real(z_betap(ip))**2
-     $              +imag(z_betap(ip))**2)
+               z_betap (ip)= csqrt(z_betap(ip))
             enddo
             enddo
             do p =-pn,pn

--- a/tests/acoustic2d/SIZE
+++ b/tests/acoustic2d/SIZE
@@ -1,0 +1,184 @@
+c     Dimension file to be included     
+c                                       
+c     HCUBE array dimensions            
+                                        
+      integer    ldim, lxi, lx1, ly1, lz1, lelv, lelt, lp, lelg
+      integer    lxs, lys, lzs, lgmres,lfdm
+      parameter (ldim=  2)
+      parameter (lxi =  3) !polynomial order for quarature: 15, bessel lxi=9
+      parameter (lx1 = lxi+1,ly1=lxi+1,lz1=1+lxi*(ldim-2))
+      parameter (lelv= 16, lelt=lelv) 
+      parameter (lp  = 4)              
+      parameter (lelg= 16)          
+      parameter (lxs=1,lys=lxs,lzs=(lxs-1)*(ldim-2)+1)
+      !parameter (lgmres=40)               
+      parameter (lgmres=lx1*ly1*lz1*lelt)               
+      parameter (lfdm  =0)  !global fast diagonalization method (1=on; 0=off)
+
+c     Choose meshes: if mesh=0 (hex/quad), if mesh=1 (tet/tri)
+c     Build  basis : DG (default), if nedelec=1 (nedelec)
+      integer    mesh, nedelec
+      parameter (mesh    = 0)
+      parameter (nedelec = 0)
+
+c     Arrays for new GEOM in TMPINPUT: temporary
+      integer    lpts,lxzfl,lxyzm            
+      parameter (lpts = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl= lx1*lz1*2*ldim*lelt)
+      parameter (lxyzm= lx1*ly1*lz1        )
+
+c     Assign different size for different solvers
+      integer    lpts1,lxzfl1,lpts2,lxzfl2,lpts3,lxzfl3,lpts4,lxzfl4
+      integer    lpts5,lxzfl5,lfp,lxd,lyd,lzd
+      integer    lpts10,lxzfl10
+
+c     Arrays for Maxwell solver
+      parameter (lpts1 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl1= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Drude/Lorentz/Hydraulic Models with Maxwell
+      parameter (lpts10 = 1) !lpts1 )
+      parameter (lxzfl10= 1) !lxzfl1)
+
+c     Arrays for Schrodinger solver 
+      parameter (lpts2 = 1) !(lpts2= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl2= 1) !(lxzfl2= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Acoustic solver 
+      parameter (lpts3 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl3= lx1*lz1*2*ldim*lelt)
+      parameter (lfp   = 5 ) ! fourier points for DtN operator
+
+c     Arrays for Drift-Diffusion solver
+      parameter (lpts4 = 1) !lx1*ly1*lz1*lelt   )
+      parameter (lxzfl4= 1) !lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Nedelec solver
+c     parameter (lxd=lx1,lyd=ly1,lzd=lz1)
+      parameter (lxd=1,lyd=1,lzd=1)
+      parameter (lpts5 =1)! lxd*lyd*lzd*lelt   )
+      parameter (lxzfl5=1)! lxd*lzd*2*ldim*lelt)
+
+c     Arrays for Eigenvalue calculations: when not using set it as 1
+      integer    lpts_eig
+      parameter (lpts_eig =lx1*ly1*lz1*lelt*2*ldim)
+
+c     Arrays for Quantum Model calculations
+      integer    level,lnumqd,lnumsp,lstate,lrho,leqn,lEh
+      parameter (level   = 1      )       ! number of qd states
+      parameter (lnumqd  = 1      )       ! number of surface plasmon states
+      parameter (lnumsp  = 1      )       ! number of surface plasmon states
+      parameter (lstate  = level**lnumqd*lnumsp)   ! number of total states
+      parameter (lrho    = lstate*lstate) ! number of rho
+      parameter (leqn    = 1      )       ! number of eqns: real/imag
+      parameter (lEh     = 1      )       ! number of energy
+
+c     Exponential Integrator
+      integer    larnol,luniform,levg,lelg2d,lmov,lw
+      parameter (larnol  = 1)
+      parameter (luniform= 1)
+      parameter (levg    = 1)
+      parameter (lelg2d  = 9)
+      parameter (lmov    = 0)
+      parameter (lw      = 5)
+
+c     Interpolation: lpart = the number of points for interpolation
+      integer    lpart
+      parameter (lpart= 1)
+
+c     Arrays for .box mesh                 
+      integer    lelx , lely , lelz
+      integer    lpelv, lpelt, lpert  
+      integer    lpx1 , lpy1 , lpz1 
+      integer    lpx2 , lpy2 , lpz2
+      integer    lbelt, lbelv 
+      integer    lbx1 , lby1 , lbz1 
+      integer    lbx2 , lby2 , lbz2 
+      parameter (lelx =4,lely =lelx,lelz =1)!lelx )
+      parameter (lpelv=1,lpelt=lpelv,lpert=lpelv)
+      parameter (lpx1 =1,lpy1 =lpx1 ,lpz1 =lpx1 )
+      parameter (lpx2 =1,lpy2 =lpx2 ,lpz2 =lpx2 )
+      parameter (lbelv=lelv, lbelt=lelv )
+      parameter (lbx1 =1,lby1 =lbx1 ,lbz1 =lbx1 )
+      parameter (lbx2 =1,lby2 =lbx2 ,lbz2 =lbx2 )
+ 
+      integer    lzl 
+      integer    lx2, ly2, lz2
+      integer    lx3, ly3, lz3
+      integer    lx1m, ly1m, lz1m
+      integer    ldimt, ldimt1, ldimt3
+
+      PARAMETER (LZL=1+2*(ldim-2))
+      PARAMETER (LX2=LX1)
+      PARAMETER (LY2=LY1)
+      PARAMETER (LZ2=LZ1)
+      PARAMETER (LX3=LX1)
+      PARAMETER (LY3=LY1)
+      PARAMETER (LZ3=LZ1)
+c     PARAMETER (lxd=3*lx1/2+1,lyd=3*ly1/2+1,lzd=3*lz1/2+1)
+
+C     LX1M=LX1 when there are moving meshes; =1 otherwise
+      PARAMETER (LX1M  =1,LY1M=1,LZ1M=1)
+      PARAMETER (LDIMT = 1)
+      PARAMETER (LDIMT1= LDIMT+1)
+      PARAMETER (LDIMT3= LDIMT+3)
+ 
+c
+c     Note:  In the new code, LELGEC should be about sqrt(LELG)
+c
+      integer    lelgec, lxyz2, lxz21
+      PARAMETER (LELGEC = 1)
+      PARAMETER (LXYZ2  = 1)
+      PARAMETER (LXZ21  = 1)
+c
+c     integer    lmaxv, lmaxt, lmaxp
+      integer    lxz, lorder, maxobj, maxmbr
+c     PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
+c     PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
+c     PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
+      PARAMETER (LXZ=LX1*LZ1)
+      PARAMETER (LORDER=3)              
+      PARAMETER (MAXOBJ=2,MAXMBR=LELT*6)
+C                                       
+C     Common Block Dimensions           
+C
+      integer    lctmp0, lctmp1
+      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)     
+      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
+C
+C     The parameter LVEC controls whether an additional 42 field arrays
+C     are required for Steady State Solutions.  If you are not using
+C     Steady State, it is recommended that LVEC=1.
+C
+      integer    lvec
+      PARAMETER (LVEC=1)
+C
+C     Uzawa projection array dimensions
+C
+c     PARAMETER (MXPREV = 01)
+C
+C     Split projection array dimensions
+C
+      integer    lmvec, lsvec, lstore
+      parameter (lmvec = 1)
+      parameter (lsvec = 1)
+      parameter (lstore=lmvec*lsvec)
+c
+c     NONCONFORMING STUFF
+c
+      integer    maxmor
+      parameter (maxmor = lelt)
+C
+C     Array dimensions                  
+C
+      integer    nelv, nelt
+      integer    nx1, ny1, nz1
+      integer    nx2, ny2, nz2
+      integer    nx3, ny3, nz3
+      integer    ndim, nfield, nid, npert
+      integer    nxyz, npts, nxzf, nxzfl, nfaces
+
+      COMMON /DIMN/
+     $           NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
+     $          ,NX3,NY3,NZ3,NDIM,NFIELD,NID,NPERT
+     $          ,NXYZ,NPTS,NXZF,NXZFL,NFACES

--- a/tests/acoustic2d/pec.box
+++ b/tests/acoustic2d/pec.box
@@ -1,0 +1,14 @@
+dummy.rea
+2
+1                      number of fields
+#
+#    comments
+#
+#
+#========================================================
+#
+Box
+-4  -4 (number of elements in x,y)
+-1  1   1              (x0,x1,gain)
+-1  1   1              (x0,x1,gain)
+P  ,P  ,PEC,DTN                         (bc's)

--- a/tests/acoustic2d/pec.rea
+++ b/tests/acoustic2d/pec.rea
@@ -1,0 +1,163 @@
+ ****** PARAMETERS *****
+    2.610000     NEKTON VERSION
+2 DIMENSIONAL RUN
+103 PARAMETERS FOLLOW
+  0.299792E+18                  1: x CSPEED The speed of light, in m/s.
+  0.885420E-20                  2: x PERMIT Vacuum permittivity (\epsilon_0)
+  0.125660E-14                  3: x PERMEA Vacuum permeability (\mu_0)
+  1                             4: x IFTE (1), IFTM (2)
+  0                             5: x IFMAXWELL=0,1,2,...;IFSCHROD=10,11,...; IFDRIFT=20,21,....,29(DG); IFDRIFT=30(w/o exciton),31(w/ exciton),39(SEM);
+  0                             6: x source turn on(1); turn off(0)
+  0                             7: x inhomogeneous boundary turn on (1)
+  0                             8: x # of field (default=0)
+  0                             9: ---
+  1e20                          10: x FINTIME: Final Time
+  0                             11: x NSTEPS: Total # of timesteps
+  0.2                           12: x DT:  Timestep Size with (-), eg. -0.05; CFL number with (+), eg, CFL=0.2,0.3,0.4
+  100                           13: x IOCOMM : Print statement at every IOCOMM step
+  0.000000E+00                  14: x OPTIONS: number of periods (nano)
+  100                           15: x IOSTEP : Produce outputs at every IOSTEP
+  1                             16: x IFSOL: 1 (solution assgined), 0 (if not)
+  0                             17: x Timestep: 10(EIG),0 or 45(RK45),44(rk44),33(rk33),22(rk22), 1(EXP), -1(BDF1), -2(BDF2)
+  0                             18: x Filter: 0 (no filter), 1 (turn on filter), Dealias: -1 (turn on dealias)
+  0                             19: x FLUXES: 0 (upwind flux), 1 (central flux)
+  5.00000                       20: x ORDER (MESH): positive value
+  1                             21: x define poisson solver --> GMRES(1), CG(2), GMRES-SEMG(3); negative sign w/ projection GMRES(-1), CG(-2), GMRES-SEMG(-3)
+  1e-10                         22: x tolerance      : (GMRES, CG, GMRES-SEMG)
+  0                             23: x preconditioner : FDM for CG(1)
+  0                             24: x define unsteady time dependent solver --> GMRES(1), CG(2); negative sign w/ projection GMRES(-1), CG(-2)                  
+  0                             25: x drift-diffusion GFDM (global fast diagonalization): GFDMDD (1)         
+  0                             26: ---  
+  3.00000                       27: x TORDER
+  0.000000E+00                  28: x TMESH
+  0.000000E+00                  29: ---
+  0.000000E+00                  30: ---
+  0.000000E+00                  31: ---
+  0.000000E+00                  32: ---
+  0                             33: ---
+  0                             34: ---
+  0                             35: ---
+  0                             36: ---
+  0                             37: ---
+  0.000000E+00                  38: ---
+  0.000000E+00                  39: ---
+  0.000000E+00                  40: ---
+  0.000000E+00                  41: ---
+  0.000000E+00                  42: ---
+  0                             43: ---
+  0.000000E+00                  44: ---
+  0.000000E+00                  45: ---
+  0.000000E+00                  46: ---
+  0.000000E+00                  47: ---
+  0.000000E+00                  48: ---
+  0.140000                      49: ---
+  0.000000E+00                  50: ---
+  0.000000E+00                  51: ---
+  0.000000E+00                  52: ---
+  0.000000E+00                  53: ---
+  0.000000E+00                  54: ---
+  0.000000E+00                  55: ---
+  0.000000E+00                  56: ---
+  0                             57: ---
+  0                             58: ---
+  0                             59: ---
+  0                             60: ---
+  0                             61: ---
+  0                             62: ---
+  0                             63: ---
+  0                             64: ---
+  0                             65: ---
+  0                             66: ---
+  0                             67: ---
+  0                             68: ---
+  0                             69: ---
+  0                             70: ---
+  0                             71: ---
+  0                             72: ---
+  0                             73: ---
+  0                             74: ---
+  0                             75: ---
+  0                             76: ---
+  1.000000E+00                  77: x PMLTHICK : thickness of the PML in levels
+  2.000000E+00                  78: x PMLORDER : polynomial order of the grading of the PML parameter sigma
+  1.000000E-05                  79: x PMLREFERR : PML reflection error
+  4                             80: x I/O: total (exact) number of output fields: currently default=4
+  4                             81: x I/O: 0 (no output), 1 (fld),2 (posix ascii),3 (posix binary), 4,5, (coIO), 6,-6,8 (rbIO)
+  1                             82: x I/O: the number of outputfiles per timestep
+  0                             83: x I/O: frequency of restart output files, 0 (no restart output), #nn (iostep*nn)
+  0                             84: x RESTART (should be 0 for non-mpi run): invoked with dump_number from the name of the restarting output file
+  0                             85: x computation trace active if positive number
+  0                             86: x io trace active if positive number
+  0                             87: x I/O: "1" on BGP ;if >0, write/read restart files in float; if 0 (=default), double
+  0                             88: ---
+  0                             89: ---
+  0                             90: ---
+  0                             91: ---
+  0                             92: ---
+  1                             93: x ifdielec  0: false 1: true
+  0                             94: x ific      0: false 1: true
+  0                             95: x ifpoisson 0: false 1: true
+  0                             96: ---
+  0                             97: --- x ifarpack 0: false 1: true
+  0                             98: ---
+  0                             99: ---
+  0                             100: x 0: default, 1: ifscat, 2: ifsftf
+  0                             101: x ifdrude 0: false 1: true
+  0                             102: ---
+  0                             103: ---
+			4  Lines of passive scalar data follows2 CONDUCT; 2RHOCP
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000    
+13 LOGICAL SWITCHES FOLLOW
+  F                             1: IFFLOW
+  T                             2: IFHEAT
+  T                             3: IFTRAN
+  F                             4: IFSRC
+  T                             5: IFCENTRAL
+  F                             6: IFUPWIND
+  F                             7: IFTM (2D only)
+  T                             8: IFTE (2D only)
+  F                             9: IFDEALIAS
+  F                             10: IFRK4
+  T                             11: IFEXP
+  F                             12: IFEIG
+  F                             13: IFNM
+  9.23077       9.23077      -4.38462      -5.30769     XFAC,YFAC,XZERO,YZERO
+ **MESH DATA** 1st line is X of corner 1,2,3,4. 2nd line is Y.
+    9     -2     9          NEL,NDIM,NELV
+flat.box
+            0 PRESOLVE/RESTART OPTIONS  *****
+            7         INITIAL CONDITIONS *****
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+C Default                                                                       
+  ***** DRIVE FORCE DATA ***** BODY FORCE, FLOW, Q
+            4                 Lines of Drive force data follow
+C                                                                               
+C                                                                               
+C                                                                               
+C                                                                               
+  ***** Variable Property Data ***** Overrrides Parameter data.
+            1 Lines follow.
+            0 PACKETS OF DATA FOLLOW
+  ***** HISTORY AND INTEGRAL DATA ***** 
+            0   POINTS.  Hcode, I,J,H,IEL
+  ***** OUTPUT FIELD SPECIFICATION *****
+            6 SPECIFICATIONS FOLLOW
+  F      COORDINATES
+  F      VELOCITY
+  F      PRESSURE
+  T      TEMPERATURE
+  F      TEMPERATURE GRADIENT
+            0      PASSIVE SCALARS
+  ***** OBJECT SPECIFICATION *****
+       0 Surface Objects 
+       0 Volume  Objects 
+       0 Edge    Objects 
+       0 Point   Objects 

--- a/tests/acoustic2d/pec.usr
+++ b/tests/acoustic2d/pec.usr
@@ -1,0 +1,358 @@
+c-----------------------------------------------------------------------
+c
+c  USER SPECIFIED ROUTINES:
+c
+c     - boundary conditions
+c     - initial conditions
+c     - variable properties
+c     - forcing function for fluid (f)
+c     - forcing function for passive scalar (q)
+c     - general purpose routine for checking errors etc.
+c
+c-----------------------------------------------------------------------
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userini(tt, myhx, myhy, myhz, myex, myey, myez)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+      include 'ZCOUSTIC'
+
+      real myhx(lx1,ly1,lz1,lelt)
+      real myhy(lx1,ly1,lz1,lelt)
+      real myhz(lx1,ly1,lz1,lelt)
+      real myex(lx1,ly1,lz1,lelt)
+      real myey(lx1,ly1,lz1,lelt)
+      real myez(lx1,ly1,lz1,lelt)
+
+      complex*16 ci, z_d1,z_d2
+      complex*16 z_tmpk1, z_tmpk2
+      complex*16 z_tmp  , z_tmp2
+      complex*16 z_tmp_kwave1
+      complex*16 z_tmp_kwave2
+      integer e
+      real    tt,energy_err,flag(6)
+
+
+c..   user defined wavenumber for different DTN directions
+      ci  =(0.0,1.0)
+      z_kw(1)= 0   ! negative x-direction DTN
+      z_kw(2)= 0   ! positive x-direction DTN
+      z_kw(3)= 0   ! negative y-direction DTN
+      z_kw(4)= 1.5 ! positive y-direction DTN
+      z_kw(5)= 0   ! negative z-direction DTN
+      z_kw(6)= 0   ! positive z-direction DTN
+
+      call rzero(flag,6)
+      flag(4)=1!incident from top
+c..   only for the energy test
+      kw(3)= real(z_kw(3))
+      kw(4)= real(z_kw(4))
+
+c...  assign temporary values of wavenumber kw
+      alp0 = 1.0
+      z_tmpk1= alp0
+      z_tmpk2= cdsqrt(z_kw(4)**2-alp0**2)
+
+C...  define parameters for multilayer
+      do e=1,nelt
+         z_alpha0(e)= z_tmpk1
+         z_beta0 (e)= z_tmpk2
+      enddo
+
+C...  box mesh with periodic boundary
+      n = npts
+      n2= npts*2
+
+      do e= 1,nelt
+
+         z_tmp_kwave1 = z_kw(4)
+         z_tmp_kwave2 = z_beta0(e)**2
+         do i= 1,nxyz
+            j= i+(e-1)*nxyz
+            xx= xm1(j,1,1,1)
+            yy= ym1(j,1,1,1)
+            zz= zm1(j,1,1,1)
+            z_kwave1 (  j) = z_tmp_kwave1
+            z_kwave2 (  j) = z_tmp_kwave2
+c     Incident wave
+            z_rhs_inc(  j) = exp(ci*(z_alpha0(e)*xx
+     $           -z_beta0(e)*(yy+1.0)))
+c     Exact solution
+            z_spotent(  j) = z_rhs_inc(j)-exp(ci*(z_alpha0(e)*xx
+     $           +z_beta0(e)*(yy-1.0)))
+         enddo
+
+      enddo
+ 10   format(i5,4f13.5)
+
+      call z2r_copy(rhs_inc(1),rhs_inc(n+1),z_rhs_inc,n)
+      call cem_dtn_quasi_sol(rhs_inc(1),alp0,2)
+      call r2z_copy(z_rhs_inc,rhs_inc(1),rhs_inc(n+1),n)
+
+      call cem_grad(dxinc(  1),dyinc(  1),dzinc(  1),rhs_inc(  1))
+      call cem_grad(dxinc(n+1),dyinc(n+1),dzinc(n+1),rhs_inc(n+1))
+      call copy (rhs_nmn,dyinc,n2) ! assing neumman part boundary condition
+c...  call chsign(rhs_nmn,n2)      ! n*(dxinc,dyinc,dzinc)
+      call r2z_copy(z_rhs_nmn,rhs_nmn(1),rhs_nmn(n+1),n)
+
+      call z_hmhDtN  ! return potent --> total field
+
+      call cem_dtn_quasi_sol(potent(1),alp0,1)
+      call cem_dtn_quasi_sol(rhs_inc(1),alp0,1)
+
+      call r2z_copy(z_potent,potent(1),potent(n+1),n)
+
+      call sub3(scaten(1,2),potent(  1),rhs_inc(  1),n) ! scattered field
+      call sub3(scathn(1,2),potent(n+1),rhs_inc(n+1),n)
+
+      call cem_acoustic_test2(energy_err,flag,real(z_beta0(nelt)))
+
+      call copy(en(1,1),potent (  1),n)   ! numeric total field real
+      call copy(hn(1,1),potent (n+1),n)   ! numeric total field imag
+      call copy(en(1,2),scaten (1,2),n)   ! numeric scattered real
+      call copy(hn(1,2),scathn (1,2),n)   ! numeric scattered real
+
+      call z2r_copy(spotent(1),spotent(n+1),z_spotent,n)
+
+      call copy(en(1,3),spotent(  1),n)   ! exact total field real
+      call copy(hn(1,3),spotent(n+1),n) ! exact total field imag
+
+      call cem_out
+
+      call sub3(epotent(  1),potent(  1),spotent(  1),n)
+      call sub3(epotent(n+1),potent(n+1),spotent(n+1),n)
+
+      smax1  = glmax (scaten (1,2),n)
+      smax2  = glmax (scathn (1,2),n)
+      smin1  = glmin (scaten (1,2),n)
+      smin2  = glmin (scathn (1,2),n)
+
+      pmax1  = glmax (potent (  1),n)
+      pmax2  = glmax (potent (n+1),n)
+      pmin1  = glmin (potent (  1),n)
+      pmin2  = glmin (potent (n+1),n)
+
+      errmax1= glamax(epotent(  1),n)
+      errmax2= glamax(epotent(n+1),n)
+
+      if (nid.eq.0) write(6,20)  smax1  ,smin1
+      if (nid.eq.0) write(6,30)  smax2  ,smin2
+      if (nid.eq.0) write(6,40)  pmax1  ,pmin1
+      if (nid.eq.0) write(6,50)  pmax2  ,pmin2
+      if (nid.eq.0) write(6,60)  errmax1,errmax2,nx1-1,nelt,nelgt,np
+
+ 20   format(' val_sct    :: real max/min=',2e25.15)
+ 30   format(' val_sct    :: imag max/min=',2e25.15)
+ 40   format(' val_tot    :: real max/min=',2e25.15)
+ 50   format(' val_tot    :: imag max/min=',2e25.15)
+ 60   format(' val_err_tot::    real/imag:',2e25.15,4i8)
+
+      if (errmax1.gt.2.0e-4) then
+         write(*,*) 'ERROR: error in the real part is too large'
+         call exitt(1)
+      elseif (errmax2.gt.2.0e-4) then
+         write(*,*) 'ERROR: error in the imaginary part is too large'
+         call exitt(1)
+      endif
+
+      call exitt(0)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersol(tt, myshx, myshy, myshz, mysex, mysey, mysez)
+c-----------------------------------------------------------------------
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+      real tt
+      real myshx(lx1,ly1,lz1,lelt)
+      real myshy(lx1,ly1,lz1,lelt)
+      real myshz(lx1,ly1,lz1,lelt)
+      real mysex(lx1,ly1,lz1,lelt)
+      real mysey(lx1,ly1,lz1,lelt)
+      real mysez(lx1,ly1,lz1,lelt)
+
+c     npts=nx1*ny1*nz1*nelt
+
+      do i = 1,npts
+         xx= xm1(i,1,1,1)
+         yy= ym1(i,1,1,1)
+         zz= zm1(i,1,1,1)
+         myshx(i,1,1,1)  =-pi*sin(pi*xx)*cos(pi*yy)
+         myshy(i,1,1,1)  =-pi*cos(pi*xx)*sin(pi*yy)
+         myshz(i,1,1,1)  = 0
+         mysex(i,1,1,1)  =-pi*sin(pi*xx)*cos(pi*yy)
+         mysey(i,1,1,1)  =-pi*cos(pi*xx)*sin(pi*yy)
+         mysez(i,1,1,1)  = 0
+      enddo
+
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userfsrc(tt,srcfhx,srcfhy,srcfhz,srcfex,srcfey,srcfez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real srcfhx(lxzfl),srcfhy(lxzfl),srcfhz(lxzfl)
+      real srcfex(lxzfl),srcfey(lxzfl),srcfez(lxzfl)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine uservp(ix,iy,iz,iel)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+c     These don't do anything! This is a temporary measure until
+c
+c     https://github.com/NekCEM/NekCEM/issues/12
+c
+c     is resolved.
+      integer ix,iy,iz,iel
+
+      integer i
+
+      do i = 1,npts
+         permittivity(i) = 1.0
+         permeability(i) = 1.0
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userq  (ix,iy,iz,ieg)
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE'
+C
+      qvol   = 0.0
+      source = 0.0
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine useric (ix,iy,iz,ieg)
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE'
+C
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userbc (ix,iy,iz,iside,ieg)
+      include 'SIZE'
+      include 'TOTAL'
+      include 'NEKUSE'
+
+      ux=0.0
+      uy=0.0
+      uz=0.0
+      temp=0.0
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat
+
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+      include 'NEKUSE'
+
+      return
+      end
+
+c-----------------------------------------------------------------------
+      subroutine usrdat2
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+      integer  e
+
+      n    = nx1*ny1*nz1*nelv
+
+c     ifxyo= .true.
+
+      xmin = glmin(xm1,n)
+      xmax = glmax(xm1,n)
+      ymin = glmin(ym1,n)
+      ymax = glmax(ym1,n)
+      zmin = glmin(zm1,n)
+      zmax = glmax(zm1,n)
+
+c     if (nid.eq.0) write(6,*) wavenumber,' This is wavenumber'
+
+      sx = 2.0*pi/(xmax-xmin)
+      sy = 1.0/(ymax-ymin)
+
+      if (if3d) sz = 2.0/(zmax-zmin)
+      nmscale = 2.0/(xmax-xmin)   ! nanoscale
+
+      if (if3d) then
+
+         do i=1,n
+            xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0
+            ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0
+            zm1(i,1,1,1) = sz*(zm1(i,1,1,1)-zmin)-1.0
+         enddo
+
+      else
+         do i=1,n
+            xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)
+            ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)
+         enddo
+      endif
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userft
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userchk
+      implicit none
+
+      return
+      end
+c-----------------------------------------------------------------------

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -238,5 +238,13 @@
 	"rea": "3dboxpecp",
 	"params": {},
 	"parallelization": ["mpi"]
+    },
+    "acoustic2d-pec": {
+	"app": "maxwell",
+	"dir": "acoustic2d",
+	"usr": "pec",
+	"rea": "pec",
+	"params": {},
+	"parallelization": ["mpi"]
     }
 }


### PR DESCRIPTION
It is adapted from the old `z_flat.usr` file in the SVN repo, and it
tests a flat interface with PEC boundary conditions. The code needs
more cleaning up, but I'm trying to initially commit the file with the
minimal changes needed to make it run.

This also fixes a bug introduced into the acoustic solver in
856870ee4948490ece3fac1d2b6e74803cb59dfc where a complex square root
was incorrectly changed to a norm.