### PR TITLE
Clean up/improvements for `acoustic2d-pec` test

### DIFF
--- a/tests/acoustic2d/SIZE
+++ b/tests/acoustic2d/SIZE
@@ -1,18 +1,18 @@
-c     Dimension file to be included     
-c                                       
-c     HCUBE array dimensions            
-                                        
+c     Dimension file to be included
+c
+c     HCUBE array dimensions
+
       integer    ldim, lxi, lx1, ly1, lz1, lelv, lelt, lp, lelg
       integer    lxs, lys, lzs, lgmres,lfdm
-      parameter (ldim=  2)
-      parameter (lxi =  3) !polynomial order for quarature: 15, bessel lxi=9
+      parameter (ldim =  2)
+      parameter (lxi =  8) !polynomial order for quarature: 15, bessel lxi=9
       parameter (lx1 = lxi+1,ly1=lxi+1,lz1=1+lxi*(ldim-2))
-      parameter (lelv= 16, lelt=lelv) 
-      parameter (lp  = 4)              
-      parameter (lelg= 16)          
+      parameter (lelv= 16, lelt=lelv)
+      parameter (lp  = 4)
+      parameter (lelg= 16)
       parameter (lxs=1,lys=lxs,lzs=(lxs-1)*(ldim-2)+1)
-      !parameter (lgmres=40)               
-      parameter (lgmres=lx1*ly1*lz1*lelt)               
+      !parameter (lgmres=40)
+      parameter (lgmres=lx1*ly1*lz1*lelt)
       parameter (lfdm  =0)  !global fast diagonalization method (1=on; 0=off)
 
 c     Choose meshes: if mesh=0 (hex/quad), if mesh=1 (tet/tri)
@@ -22,7 +22,7 @@ c     Build  basis : DG (default), if nedelec=1 (nedelec)
       parameter (nedelec = 0)
 
 c     Arrays for new GEOM in TMPINPUT: temporary
-      integer    lpts,lxzfl,lxyzm            
+      integer    lpts,lxzfl,lxyzm
       parameter (lpts = lx1*ly1*lz1*lelt   )
       parameter (lxzfl= lx1*lz1*2*ldim*lelt)
       parameter (lxyzm= lx1*ly1*lz1        )
@@ -40,11 +40,11 @@ c     Arrays for Drude/Lorentz/Hydraulic Models with Maxwell
       parameter (lpts10 = 1) !lpts1 )
       parameter (lxzfl10= 1) !lxzfl1)
 
-c     Arrays for Schrodinger solver 
+c     Arrays for Schrodinger solver
       parameter (lpts2 = 1) !(lpts2= lx1*ly1*lz1*lelt   )
       parameter (lxzfl2= 1) !(lxzfl2= lx1*lz1*2*ldim*lelt)
 
-c     Arrays for Acoustic solver 
+c     Arrays for Acoustic solver
       parameter (lpts3 = lx1*ly1*lz1*lelt   )
       parameter (lxzfl3= lx1*lz1*2*ldim*lelt)
       parameter (lfp   = 5 ) ! fourier points for DtN operator
@@ -86,14 +86,14 @@ c     Interpolation: lpart = the number of points for interpolation
       integer    lpart
       parameter (lpart= 1)
 
-c     Arrays for .box mesh                 
+c     Arrays for .box mesh
       integer    lelx , lely , lelz
-      integer    lpelv, lpelt, lpert  
-      integer    lpx1 , lpy1 , lpz1 
+      integer    lpelv, lpelt, lpert
+      integer    lpx1 , lpy1 , lpz1
       integer    lpx2 , lpy2 , lpz2
-      integer    lbelt, lbelv 
-      integer    lbx1 , lby1 , lbz1 
-      integer    lbx2 , lby2 , lbz2 
+      integer    lbelt, lbelv
+      integer    lbx1 , lby1 , lbz1
+      integer    lbx2 , lby2 , lbz2
       parameter (lelx =4,lely =lelx,lelz =1)!lelx )
       parameter (lpelv=1,lpelt=lpelv,lpert=lpelv)
       parameter (lpx1 =1,lpy1 =lpx1 ,lpz1 =lpx1 )
@@ -101,8 +101,8 @@ c     Arrays for .box mesh
       parameter (lbelv=lelv, lbelt=lelv )
       parameter (lbx1 =1,lby1 =lbx1 ,lbz1 =lbx1 )
       parameter (lbx2 =1,lby2 =lbx2 ,lbz2 =lbx2 )
- 
-      integer    lzl 
+
+      integer    lzl
       integer    lx2, ly2, lz2
       integer    lx3, ly3, lz3
       integer    lx1m, ly1m, lz1m
@@ -122,7 +122,7 @@ C     LX1M=LX1 when there are moving meshes; =1 otherwise
       PARAMETER (LDIMT = 1)
       PARAMETER (LDIMT1= LDIMT+1)
       PARAMETER (LDIMT3= LDIMT+3)
- 
+
 c
 c     Note:  In the new code, LELGEC should be about sqrt(LELG)
 c
@@ -137,13 +137,13 @@ c     PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
 c     PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
 c     PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
       PARAMETER (LXZ=LX1*LZ1)
-      PARAMETER (LORDER=3)              
+      PARAMETER (LORDER=3)
       PARAMETER (MAXOBJ=2,MAXMBR=LELT*6)
-C                                       
-C     Common Block Dimensions           
+C
+C     Common Block Dimensions
 C
       integer    lctmp0, lctmp1
-      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)     
+      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
       PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
 C
 C     The parameter LVEC controls whether an additional 42 field arrays
@@ -169,7 +169,7 @@ c
       integer    maxmor
       parameter (maxmor = lelt)
 C
-C     Array dimensions                  
+C     Array dimensions
 C
       integer    nelv, nelt
       integer    nx1, ny1, nz1

--- a/tests/acoustic2d/pec.rea
+++ b/tests/acoustic2d/pec.rea
@@ -25,9 +25,9 @@
   1                             21: x define poisson solver --> GMRES(1), CG(2), GMRES-SEMG(3); negative sign w/ projection GMRES(-1), CG(-2), GMRES-SEMG(-3)
   1e-10                         22: x tolerance      : (GMRES, CG, GMRES-SEMG)
   0                             23: x preconditioner : FDM for CG(1)
-  0                             24: x define unsteady time dependent solver --> GMRES(1), CG(2); negative sign w/ projection GMRES(-1), CG(-2)                  
-  0                             25: x drift-diffusion GFDM (global fast diagonalization): GFDMDD (1)         
-  0                             26: ---  
+  0                             24: x define unsteady time dependent solver --> GMRES(1), CG(2); negative sign w/ projection GMRES(-1), CG(-2)
+  0                             25: x drift-diffusion GFDM (global fast diagonalization): GFDMDD (1)
+  0                             26: ---
   3.00000                       27: x TORDER
   0.000000E+00                  28: x TMESH
   0.000000E+00                  29: ---
@@ -71,7 +71,7 @@
   0                             67: ---
   0                             68: ---
   0                             69: ---
-  0                             70: ---
+  1.0                           70: ---
   0                             71: ---
   0                             72: ---
   0                             73: ---
@@ -106,10 +106,10 @@
   0                             102: ---
   0                             103: ---
 			4  Lines of passive scalar data follows2 CONDUCT; 2RHOCP
-   1.00000       1.00000       1.00000       1.00000       1.00000    
-   1.00000       1.00000       1.00000       1.00000    
-   1.00000       1.00000       1.00000       1.00000       1.00000    
-   1.00000       1.00000       1.00000       1.00000    
+   1.00000       1.00000       1.00000       1.00000       1.00000
+   1.00000       1.00000       1.00000       1.00000
+   1.00000       1.00000       1.00000       1.00000       1.00000
+   1.00000       1.00000       1.00000       1.00000
 13 LOGICAL SWITCHES FOLLOW
   F                             1: IFFLOW
   T                             2: IFHEAT
@@ -130,23 +130,23 @@
 flat.box
             0 PRESOLVE/RESTART OPTIONS  *****
             7         INITIAL CONDITIONS *****
-C Default                                                                       
-C Default                                                                       
-C Default                                                                       
-C Default                                                                       
-C Default                                                                       
-C Default                                                                       
-C Default                                                                       
+C Default
+C Default
+C Default
+C Default
+C Default
+C Default
+C Default
   ***** DRIVE FORCE DATA ***** BODY FORCE, FLOW, Q
             4                 Lines of Drive force data follow
-C                                                                               
-C                                                                               
-C                                                                               
-C                                                                               
+C
+C
+C
+C
   ***** Variable Property Data ***** Overrrides Parameter data.
             1 Lines follow.
             0 PACKETS OF DATA FOLLOW
-  ***** HISTORY AND INTEGRAL DATA ***** 
+  ***** HISTORY AND INTEGRAL DATA *****
             0   POINTS.  Hcode, I,J,H,IEL
   ***** OUTPUT FIELD SPECIFICATION *****
             6 SPECIFICATIONS FOLLOW
@@ -157,7 +157,7 @@ C
   F      TEMPERATURE GRADIENT
             0      PASSIVE SCALARS
   ***** OBJECT SPECIFICATION *****
-       0 Surface Objects 
-       0 Volume  Objects 
-       0 Edge    Objects 
-       0 Point   Objects 
+       0 Surface Objects
+       0 Volume  Objects
+       0 Edge    Objects
+       0 Point   Objects

--- a/tests/acoustic2d/pec.usr
+++ b/tests/acoustic2d/pec.usr
@@ -54,7 +54,7 @@ c     User defined wavenumber for different DTN directions
       flag(4) = 1               ! incident from top
 
 c     Define the components of the incident wavevector (α, -β).
-      alp0 = 1.0
+      alp0 = param(70)
       z_tmpk1 = alp0
       z_tmpk2 = cdsqrt(z_kw(4)**2-alp0**2)
       do e=1,nelt

--- a/tests/acoustic2d/pec.usr
+++ b/tests/acoustic2d/pec.usr
@@ -1,13 +1,6 @@
 c-----------------------------------------------------------------------
 c
-c  USER SPECIFIED ROUTINES:
-c
-c     - boundary conditions
-c     - initial conditions
-c     - variable properties
-c     - forcing function for fluid (f)
-c     - forcing function for passive scalar (q)
-c     - general purpose routine for checking errors etc.
+c     Plane wave striking a flat perfect electrical conductor.
 c
 c-----------------------------------------------------------------------
       subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
@@ -22,145 +15,134 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userini(tt, myhx, myhy, myhz, myex, myey, myez)
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
 c-----------------------------------------------------------------------
+      implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
       include 'NEKUSE'
       include 'ZCOUSTIC'
 
-      real myhx(lx1,ly1,lz1,lelt)
-      real myhy(lx1,ly1,lz1,lelt)
-      real myhz(lx1,ly1,lz1,lelt)
-      real myex(lx1,ly1,lz1,lelt)
-      real myey(lx1,ly1,lz1,lelt)
-      real myez(lx1,ly1,lz1,lelt)
+      real tt
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
 
-      complex*16 ci, z_d1,z_d2
-      complex*16 z_tmpk1, z_tmpk2
-      complex*16 z_tmp  , z_tmp2
-      complex*16 z_tmp_kwave1
-      complex*16 z_tmp_kwave2
-      integer e
-      real    tt,energy_err,flag(6)
+      integer e,i,j,n,n2
+      real energy_err,flag(6),alp0
+      real pmin1,pmin2,pmax1,pmax2
+      real smin1,smin2,smax1,smax2
+      real xx,yy
+      real errmax1,errmax2
+      real glmin,glmax,glamax
+      complex z_d1,z_d2
+      complex z_tmp,z_tmp2,z_tmpk1,z_tmpk2
+      complex z_tmp_kwave1,z_tmp_kwave2
+      complex ci
+      parameter (ci = (0.0,1.0))
 
-
-c..   user defined wavenumber for different DTN directions
-      ci  =(0.0,1.0)
-      z_kw(1)= 0   ! negative x-direction DTN
-      z_kw(2)= 0   ! positive x-direction DTN
-      z_kw(3)= 0   ! negative y-direction DTN
-      z_kw(4)= 1.5 ! positive y-direction DTN
-      z_kw(5)= 0   ! negative z-direction DTN
-      z_kw(6)= 0   ! positive z-direction DTN
-
+      n = npts
+      n2 = npts*2
+c     User defined wavenumber for different DTN directions
+      z_kw(1) = 0               ! negative x-direction DTN
+      z_kw(2) = 0               ! positive x-direction DTN
+      z_kw(3) = 0               ! negative y-direction DTN
+      z_kw(4) = 1.5             ! positive y-direction DTN
+      z_kw(5) = 0               ! negative z-direction DTN
+      z_kw(6) = 0               ! positive z-direction DTN
       call rzero(flag,6)
-      flag(4)=1!incident from top
-c..   only for the energy test
-      kw(3)= real(z_kw(3))
-      kw(4)= real(z_kw(4))
+      flag(4) = 1               ! incident from top
 
-c...  assign temporary values of wavenumber kw
+c     Define the components of the incident wavevector (α, -β).
       alp0 = 1.0
-      z_tmpk1= alp0
-      z_tmpk2= cdsqrt(z_kw(4)**2-alp0**2)
-
-C...  define parameters for multilayer
+      z_tmpk1 = alp0
+      z_tmpk2 = cdsqrt(z_kw(4)**2-alp0**2)
       do e=1,nelt
          z_alpha0(e)= z_tmpk1
          z_beta0 (e)= z_tmpk2
       enddo
 
-C...  box mesh with periodic boundary
-      n = npts
-      n2= npts*2
-
-      do e= 1,nelt
-
+      do e = 1,nelt
          z_tmp_kwave1 = z_kw(4)
          z_tmp_kwave2 = z_beta0(e)**2
-         do i= 1,nxyz
-            j= i+(e-1)*nxyz
-            xx= xm1(j,1,1,1)
-            yy= ym1(j,1,1,1)
-            zz= zm1(j,1,1,1)
-            z_kwave1 (  j) = z_tmp_kwave1
-            z_kwave2 (  j) = z_tmp_kwave2
+         do i = 1,nxyz
+            j = i+(e-1)*nxyz
+            xx = xm1(j,1,1,1)
+            yy = ym1(j,1,1,1)
+            z_kwave1(j) = z_tmp_kwave1
+            z_kwave2(j) = z_tmp_kwave2
 c     Incident wave
-            z_rhs_inc(  j) = exp(ci*(z_alpha0(e)*xx
-     $           -z_beta0(e)*(yy+1.0)))
+            z_rhs_inc(j) = exp(ci*(z_alpha0(e)*xx-z_beta0(e)*(yy+1.0)))
 c     Exact solution
-            z_spotent(  j) = z_rhs_inc(j)-exp(ci*(z_alpha0(e)*xx
+            z_spotent(j) = z_rhs_inc(j)-exp(ci*(z_alpha0(e)*xx
      $           +z_beta0(e)*(yy-1.0)))
          enddo
-
       enddo
- 10   format(i5,4f13.5)
+      call z2r_copy(spotent(1),spotent(n+1),z_spotent,n)
 
       call z2r_copy(rhs_inc(1),rhs_inc(n+1),z_rhs_inc,n)
       call cem_dtn_quasi_sol(rhs_inc(1),alp0,2)
       call r2z_copy(z_rhs_inc,rhs_inc(1),rhs_inc(n+1),n)
 
-      call cem_grad(dxinc(  1),dyinc(  1),dzinc(  1),rhs_inc(  1))
+      call cem_grad(dxinc(1),dyinc(1),dzinc(1),rhs_inc(1))
       call cem_grad(dxinc(n+1),dyinc(n+1),dzinc(n+1),rhs_inc(n+1))
-      call copy (rhs_nmn,dyinc,n2) ! assing neumman part boundary condition
-c...  call chsign(rhs_nmn,n2)      ! n*(dxinc,dyinc,dzinc)
+      call copy(rhs_nmn,dyinc,n2) ! PEC boundary condition
       call r2z_copy(z_rhs_nmn,rhs_nmn(1),rhs_nmn(n+1),n)
 
-      call z_hmhDtN  ! return potent --> total field
+      call z_hmhDtN             ! return potent --> total field
 
       call cem_dtn_quasi_sol(potent(1),alp0,1)
       call cem_dtn_quasi_sol(rhs_inc(1),alp0,1)
 
       call r2z_copy(z_potent,potent(1),potent(n+1),n)
 
-      call sub3(scaten(1,2),potent(  1),rhs_inc(  1),n) ! scattered field
+      call sub3(scaten(1,2),potent(1),rhs_inc(1),n) ! scattered field
       call sub3(scathn(1,2),potent(n+1),rhs_inc(n+1),n)
 
-      call cem_acoustic_test2(energy_err,flag,real(z_beta0(nelt)))
-
-      call copy(en(1,1),potent (  1),n)   ! numeric total field real
-      call copy(hn(1,1),potent (n+1),n)   ! numeric total field imag
-      call copy(en(1,2),scaten (1,2),n)   ! numeric scattered real
-      call copy(hn(1,2),scathn (1,2),n)   ! numeric scattered real
-
-      call z2r_copy(spotent(1),spotent(n+1),z_spotent,n)
-
-      call copy(en(1,3),spotent(  1),n)   ! exact total field real
+      call copy(en(1,1),potent(1),n) ! numeric total field real
+      call copy(en(1,2),scaten(1,2),n) ! numeric scattered real
+      call copy(en(1,3),spotent(1),n) ! exact total field real
+      call copy(hn(1,1),potent(n+1),n) ! numeric total field imag
+      call copy(hn(1,2),scathn(1,2),n) ! numeric scattered real
       call copy(hn(1,3),spotent(n+1),n) ! exact total field imag
-
       call cem_out
 
-      call sub3(epotent(  1),potent(  1),spotent(  1),n)
+      call sub3(epotent(1),potent(1),spotent(1),n)
       call sub3(epotent(n+1),potent(n+1),spotent(n+1),n)
 
-      smax1  = glmax (scaten (1,2),n)
-      smax2  = glmax (scathn (1,2),n)
-      smin1  = glmin (scaten (1,2),n)
-      smin2  = glmin (scathn (1,2),n)
+      smax1 = glmax(scaten(1,2),n)
+      smax2 = glmax(scathn(1,2),n)
+      smin1 = glmin(scaten(1,2),n)
+      smin2 = glmin(scathn(1,2),n)
 
-      pmax1  = glmax (potent (  1),n)
-      pmax2  = glmax (potent (n+1),n)
-      pmin1  = glmin (potent (  1),n)
-      pmin2  = glmin (potent (n+1),n)
+      pmax1 = glmax(potent(1),n)
+      pmax2 = glmax(potent(n+1),n)
+      pmin1 = glmin(potent(1),n)
+      pmin2 = glmin(potent(n+1),n)
 
-      errmax1= glamax(epotent(  1),n)
-      errmax2= glamax(epotent(n+1),n)
+      errmax1 = glamax(epotent(1),n)
+      errmax2 = glamax(epotent(n+1),n)
 
-      if (nid.eq.0) write(6,20)  smax1  ,smin1
-      if (nid.eq.0) write(6,30)  smax2  ,smin2
-      if (nid.eq.0) write(6,40)  pmax1  ,pmin1
-      if (nid.eq.0) write(6,50)  pmax2  ,pmin2
-      if (nid.eq.0) write(6,60)  errmax1,errmax2,nx1-1,nelt,nelgt,np
+      kw(3) = real(z_kw(3))
+      kw(4) = real(z_kw(4))
+      call cem_acoustic_test2(energy_err,flag,real(z_beta0(nelt)))
 
- 20   format(' val_sct    :: real max/min=',2e25.15)
- 30   format(' val_sct    :: imag max/min=',2e25.15)
- 40   format(' val_tot    :: real max/min=',2e25.15)
- 50   format(' val_tot    :: imag max/min=',2e25.15)
- 60   format(' val_err_tot::    real/imag:',2e25.15,4i8)
+      if (nid.eq.0) write(6,20) smax1,smin1
+      if (nid.eq.0) write(6,30) smax2,smin2
+      if (nid.eq.0) write(6,40) pmax1,pmin1
+      if (nid.eq.0) write(6,50) pmax2,pmin2
+      if (nid.eq.0) write(6,60) errmax1,errmax2
 
-      if (errmax1.gt.5.0e-11) then
+ 20   format(' val_sct     :: real max/min =',2e25.15)
+ 30   format(' val_sct     :: imag max/min =',2e25.15)
+ 40   format(' val_tot     :: real max/min =',2e25.15)
+ 50   format(' val_tot     :: imag max/min =',2e25.15)
+ 60   format(' val_err_tot ::    real/imag =',2e25.15)
+
+      if (energy_err.gt.1.0e-11) then
+         write(*,*) 'ERROR: energy error is too large'
+         call exitt(1)
+      elseif (errmax1.gt.5.0e-11) then
          write(*,*) 'ERROR: error in the real part is too large'
          call exitt(1)
       elseif (errmax2.gt.5.0e-11) then
@@ -173,34 +155,14 @@ c...  call chsign(rhs_nmn,n2)      ! n*(dxinc,dyinc,dzinc)
       return
       end
 c-----------------------------------------------------------------------
-      subroutine usersol(tt, myshx, myshy, myshz, mysex, mysey, mysez)
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
 c-----------------------------------------------------------------------
+      implicit none
       include 'SIZE'
-      include 'TOTAL'
-      include 'EMWAVE'
 
       real tt
-      real myshx(lx1,ly1,lz1,lelt)
-      real myshy(lx1,ly1,lz1,lelt)
-      real myshz(lx1,ly1,lz1,lelt)
-      real mysex(lx1,ly1,lz1,lelt)
-      real mysey(lx1,ly1,lz1,lelt)
-      real mysez(lx1,ly1,lz1,lelt)
-
-c     npts=nx1*ny1*nz1*nelt
-
-      do i = 1,npts
-         xx= xm1(i,1,1,1)
-         yy= ym1(i,1,1,1)
-         zz= zm1(i,1,1,1)
-         myshx(i,1,1,1)  =-pi*sin(pi*xx)*cos(pi*yy)
-         myshy(i,1,1,1)  =-pi*cos(pi*xx)*sin(pi*yy)
-         myshz(i,1,1,1)  = 0
-         mysex(i,1,1,1)  =-pi*sin(pi*xx)*cos(pi*yy)
-         mysey(i,1,1,1)  =-pi*cos(pi*xx)*sin(pi*yy)
-         mysez(i,1,1,1)  = 0
-      enddo
-
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
 
       return
       end
@@ -253,104 +215,45 @@ c     is resolved.
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userq  (ix,iy,iz,ieg)
-      include 'SIZE'
-      include 'TOTAL'
-      include 'NEKUSE'
-C
-      qvol   = 0.0
-      source = 0.0
-
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine useric (ix,iy,iz,ieg)
-      include 'SIZE'
-      include 'TOTAL'
-      include 'NEKUSE'
-C
-
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine userbc (ix,iy,iz,iside,ieg)
-      include 'SIZE'
-      include 'TOTAL'
-      include 'NEKUSE'
-
-      ux=0.0
-      uy=0.0
-      uz=0.0
-      temp=0.0
-
-      return
-      end
-c-----------------------------------------------------------------------
       subroutine usrdat
-
-      include 'SIZE'
-      include 'TOTAL'
-      include 'EMWAVE'
-      include 'NEKUSE'
+c-----------------------------------------------------------------------
+      implicit none
 
       return
       end
-
 c-----------------------------------------------------------------------
       subroutine usrdat2
+c-----------------------------------------------------------------------
+      implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'EMWAVE'
 
-      integer  e
+      integer e,i,n
+      real sx,sy
+      real xmin,ymin,xmax,ymax
+      real glmin,glmax
 
-      n    = nx1*ny1*nz1*nelv
-
-c     ifxyo= .true.
+      n = nx1*ny1*nz1*nelv
 
       xmin = glmin(xm1,n)
       xmax = glmax(xm1,n)
       ymin = glmin(ym1,n)
       ymax = glmax(ym1,n)
-      zmin = glmin(zm1,n)
-      zmax = glmax(zm1,n)
-
-c     if (nid.eq.0) write(6,*) wavenumber,' This is wavenumber'
 
       sx = 2.0*pi/(xmax-xmin)
       sy = 1.0/(ymax-ymin)
 
-      if (if3d) sz = 2.0/(zmax-zmin)
-      nmscale = 2.0/(xmax-xmin)   ! nanoscale
-
-      if (if3d) then
-
-         do i=1,n
-            xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)-1.0
-            ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)-1.0
-            zm1(i,1,1,1) = sz*(zm1(i,1,1,1)-zmin)-1.0
-         enddo
-
-      else
-         do i=1,n
-            xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)
-            ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)
-         enddo
-      endif
-
-      return
-      end
-c-----------------------------------------------------------------------
-      subroutine userft
-      include 'SIZE'
-      include 'TOTAL'
-      include 'EMWAVE'
-
+      do i = 1,n
+         xm1(i,1,1,1) = sx*(xm1(i,1,1,1)-xmin)
+         ym1(i,1,1,1) = sy*(ym1(i,1,1,1)-ymin)
+      enddo
 
       return
       end
 c-----------------------------------------------------------------------
       subroutine userchk
+c-----------------------------------------------------------------------
       implicit none
 
       return

--- a/tests/acoustic2d/pec.usr
+++ b/tests/acoustic2d/pec.usr
@@ -160,10 +160,10 @@ c...  call chsign(rhs_nmn,n2)      ! n*(dxinc,dyinc,dzinc)
  50   format(' val_tot    :: imag max/min=',2e25.15)
  60   format(' val_err_tot::    real/imag:',2e25.15,4i8)
 
-      if (errmax1.gt.2.0e-4) then
+      if (errmax1.gt.5.0e-11) then
          write(*,*) 'ERROR: error in the real part is too large'
          call exitt(1)
-      elseif (errmax2.gt.2.0e-4) then
+      elseif (errmax2.gt.5.0e-11) then
          write(*,*) 'ERROR: error in the imaginary part is too large'
          call exitt(1)
       endif

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -239,12 +239,20 @@
 	"params": {},
 	"parallelization": ["mpi"]
     },
-    "acoustic2d-pec": {
+    "acoustic2d-pec-oblique": {
 	"app": "maxwell",
 	"dir": "acoustic2d",
 	"usr": "pec",
 	"rea": "pec",
-	"params": {},
+	"params": {"70": 1.0},
+	"parallelization": ["mpi"]
+    },
+    "acoustic2d-pec-normal": {
+	"app": "maxwell",
+	"dir": "acoustic2d",
+	"usr": "pec",
+	"rea": "pec",
+	"params": {"70": 0.0},
 	"parallelization": ["mpi"]
     }
 }


### PR DESCRIPTION
This:

- increases the polynomial order in `SIZE` to reduce the errors
- cleans up the source code in the user file
- runs the test with multiple parameters so that both oblique and normally-incident plane waves are tested.