### PR TITLE
Continue cleaning up the log file

### DIFF
--- a/src/cem_drive.F
+++ b/src/cem_drive.F
@@ -559,20 +559,22 @@ c----------------------------------------------------------------------
       if (.not.usesteps) then
          nsteps = int(fintim/dt)
       endif
-
       ifirst = irststep+1
       ilast = nsteps+irststep
-      if (nsteps.eq.0) call cem_end
 
       if (nid.eq.0) then
          write(6,*) '============================'
-         write(6,*) '========  BEGIN RUN ========'
+         write(6,*) '========  Begin Run ========'
          write(6,*) '============================'
-         write(6,3) ifirst,ilast
+         write(6,3) ifirst-1,ilast
       endif
-    3 format(' istep=', i6,'    to',i10)
+    3 format(' istep =', i6,'   to',i10)
 
-c     start time stepping timers
+      call userchk
+      call cem_out
+      if (nsteps.eq.0) call cem_end
+
+c     Start time stepping timers
       cpu_t = 0.0
       acc_t = 0.0
       cpu_chk = 0.0

--- a/src/cem_maxwell.F
+++ b/src/cem_maxwell.F
@@ -199,13 +199,9 @@ c---------------------------------------------------------------------
 
       if (ifrestart) then
          call restart_swap
-         call userchk
-         call cem_out
       else
          call userini(time,HN(1,1),HN(1,2),HN(1,3),
      $                     EN(1,1),EN(1,2),EN(1,3))
-         call userchk
-         call cem_out
       endif
 
       return

--- a/src/io.F
+++ b/src/io.F
@@ -208,15 +208,10 @@ c...     iglsum is not doing smart bcast'ing, revert back to bcast -- jingfu
          iotrace     =iparam6
          idouble     =iparam7
 
-         IFDOUBLE=.true.
-         if (idouble.ne.0) IFDOUBLE=.false.
-         if (nid.eq.0) write(6,*) 'IFDOUBLE=',IFDOUBLE
-         if (nid.eq.0) write(6,*) 'param(81)=',iparam1
-         if (nid.eq.0) write(6,*) 'param(82)=',iparam2
-         if (nid.eq.0) write(6,*) 'param(83)=',irestart
-         if (nid.eq.0) write(6,*) 'dumpno   =',dumpno
+         ifdouble = .true.
+         if (idouble.ne.0) ifdouble = .false.
 
-         icalld  = 1
+         icalld = 1
          call pass_io_params(iooption,numfiles,ndim,mesh)
       endif
 


### PR DESCRIPTION
- Remove unhelpful print statements in `io.F`
- Make step 0 `userchk` get called after "Begin Run" is printed