### PR TITLE
Fix more compiler warnings

### DIFF
--- a/src/cem_drive.F
+++ b/src/cem_drive.F
@@ -878,20 +878,25 @@ C
 c-----------------------------------------------------------------------
       subroutine err_chk(ierr,string)
 C------------------------------------------------------------------------
-      character*1 string(132)
-      character*1 ostring(132)
-      character*10 s10
+      implicit none
       include 'SIZE'
       include 'TOTAL'
       include 'CTIMER'
 
+      character(*) string(132)
+      integer ierr
+
+      character ostring(132)
+      character(10) s10
+      integer iglsum,indx1,k,len
+
       ierr = iglsum(ierr,1)
-      if(ierr.eq.0) return
+      if (ierr.eq.0) return
 
       len = indx1(string,'$',1)
       call blank(ostring,132)
       write(s10,11) ierr
-   11 format(1x,' ierr=',i3)
+ 11   format(1x,' ierr = ',i3)
 
       call chcopy(ostring,string,len-1)
       call chcopy(ostring(len),s10,10)

--- a/src/nek5_coef.F
+++ b/src/nek5_coef.F
@@ -1223,14 +1223,14 @@ C
       DO 300 IX =1,NX1
       DO 300 IY =1,NY1
          WEIGHT =WXM1(IX)*WYM1(IY)
-         AREA(IX,IY,5,IEL) = SQRT(DOT(IX,IY,  1,IEL))*WEIGHT
-         AREA(IX,IY,6,IEL) = SQRT(DOT(IX,IY,NZ1,IEL))*WEIGHT
-         UNX (IX,IY,5,IEL) = -A(IX,IY,  1,IEL)
-         UNX (IX,IY,6,IEL) =  A(IX,IY,NZ1,IEL)
-         UNY (IX,IY,5,IEL) = -B(IX,IY,  1,IEL)
-         UNY (IX,IY,6,IEL) =  B(IX,IY,NZ1,IEL)
-         UNZ (IX,IY,5,IEL) = -C(IX,IY,  1,IEL)
-         UNZ (IX,IY,6,IEL) =  C(IX,IY,NZ1,IEL)
+         AREA(IX,IY,2*LDIM-1,IEL) = SQRT(DOT(IX,IY,  1,IEL))*WEIGHT
+         AREA(IX,IY,2*LDIM,  IEL) = SQRT(DOT(IX,IY,NZ1,IEL))*WEIGHT
+         UNX (IX,IY,2*LDIM-1,IEL) = -A(IX,IY,  1,IEL)
+         UNX (IX,IY,2*LDIM  ,IEL) =  A(IX,IY,NZ1,IEL)
+         UNY (IX,IY,2*LDIM-1,IEL) = -B(IX,IY,  1,IEL)
+         UNY (IX,IY,2*LDIM,  IEL) =  B(IX,IY,NZ1,IEL)
+         UNZ (IX,IY,2*LDIM-1,IEL) = -C(IX,IY,  1,IEL)
+         UNZ (IX,IY,2*LDIM,  IEL) =  C(IX,IY,NZ1,IEL)
   300 CONTINUE
 C
       CALL UNITVEC (UNX,UNY,UNZ,NSRF)


### PR DESCRIPTION
Fix the final compiler warning in `cem_drive.F` and fix some compiler warnings in `nek5_coef.F`; see the individual commit messages for details.