### PR TITLE
 Move initialization of PML parameters to earlier in `cem_drive.F`

### DIFF
--- a/src/PML
+++ b/src/PML
@@ -1,6 +1,9 @@
       common /pmlparam/
      $     pmlorder,            ! degree of the polynomial grading
-     $     pmlreferr,           ! desired reflection error from the PML
+c     How much of the incident signal is permitted to be reflected
+c     by the PML. See the term R(0) in formula (7.57) of the Taflove
+c     book.
+     $     pmlreferr,
      $     pmlthick             ! thickness of the PML in layers
       integer pmlthick
       real pmlorder,pmlreferr
@@ -14,13 +17,13 @@
       common /pml2/
      $     pmlbn(lpts1,3),
      $     pmldn(lpts1,3),
-c Source terms arising out of PML
+c     Source terms arising out of PML
      $     respmlhn(lpts1,3),
      $     respmlen(lpts1,3),
-c Time integration RHS PML fields
+c     Time integration RHS PML fields
      $     respmlbn(lpts1,3),
      $     respmldn(lpts1,3),
-c RK4 temp storage for PML-specific fields
+c     RK4 temp storage for PML-specific fields
      $     kpmlbn(lpts1,3),
      $     kpmldn(lpts1,3)
       real pmlbn,pmldn

--- a/src/cem_drive.F
+++ b/src/cem_drive.F
@@ -37,7 +37,8 @@ c----------------------------------------------------------------------
       call files
       call readat
 
-      call setvar
+      call setvar               ! read parameters from rea file
+      call set_logics           ! read parameters from rea file
 
       call setup_topo
 
@@ -56,7 +57,6 @@ c----------------------------------------------------------------------
       call opcount(2)
       call dofcnt
 
-      call set_logics
       if (ifrk) call rk_storage
 
       call walltime(setup_wtime2)

--- a/src/cem_maxwell_pml.F
+++ b/src/cem_maxwell_pml.F
@@ -7,13 +7,6 @@ c-----------------------------------------------------------------------
       include 'EMWAVE'
       include 'PML'
 
-      pmlthick = int(param(77))
-      pmlorder = param(78)
-c     How much of the incident signal is permitted to be reflected
-c     by the PML. See the term R(0) in formula (7.57) of the Taflove
-c     book.
-      pmlreferr = param(79)
-
       if ((pmlthick.lt.1).or.(pmlthick.gt.10)) then
         write (*,*) 'Something is wrong with your pmlthick setting'
         write (*,*) 'in your .rea file. It needs to be between one'

--- a/src/cem_param.F
+++ b/src/cem_param.F
@@ -8,6 +8,7 @@ c     sane.
       include 'TOTAL'
       include 'EMWAVE'
       include 'SCHROD'
+      include 'PML'
 
       ifdg = .true.             ! spectral element DG method: default
       ifse = .false.            ! spectral element method
@@ -75,6 +76,11 @@ c     sane.
       if (abs(param(21)).eq.3) ifsemg = .true.
       if (param(23).eq.1) iffdm = .true.
       if (param(25).eq.1) ifgfdmdd = .true.
+
+c     Set PML parameters for the Maxwell solver
+      pmlthick = int(param(77))
+      pmlorder = param(78)
+      pmlreferr = param(79)
 
       if (ifrk22.or.ifrk45) then
          ifrk= .true.


### PR DESCRIPTION
Currently useful parameters like `pmlthick` are not set when `usrdat2`
is called. This fixes that by:

- Moving the initialization of PML parameters to `set_logics`
- Making `set_logics` get called earlier in `cem_init`. Now it is
  called directly after `setvar`, which makes sense since `setvar` is
  a (somewhat out of date) version of `set_logics`