### PR TITLE
Fix compilation on Blue Gene/Q systems

### DIFF
--- a/bin/Makefile.inc
+++ b/bin/Makefile.inc
@@ -2,6 +2,7 @@
 ?FFLAGS?
 ?CC?
 ?CFLAGS?
+?JLFLAGS?
 ?LD?
 ?LDFLAGS?
 ?NEKBASE?
@@ -50,7 +51,7 @@ usr : dir $(USR)
 	$(FC) -c obj/subuser.F -o $(USROBJ) $(FFLAGS) -I$(NEKBASE)
 	rm obj/subuser.F
 
-jl : CFLAGS += -DAMG_DUMP -DNEW_GS_LOOPS
+jl : CFLAGS += $(JLFLAGS)
 jl : dir $(JLOBJ)
 
 dir :

--- a/bin/arch.json
+++ b/bin/arch.json
@@ -42,14 +42,13 @@
         "LD": "ftn",
         "LDFLAGS": ["-llapack", "-lblas", "-ta=nvidia:cc35,cc50,cc60"]
     },
-    "cetus": {
-	"FC": "/bgsys/drivers/ppcfloor/comm/xl/bin/mpixlf77",
-	"FFLAGS": ["-DMPIIO", "-WF,", "-qrealsize=8", "-qdpc=e",
-                   "-qsuffic=cpp=f"],
-	"CC": "/bgsys/drivers/ppcfloor/comm/xl/bin/mpixlc",
+    "blue-gene-q": {
+	"FC": "mpif77",
+	"FFLAGS": ["-WF,-DMPIIO", "-qrealsize=8", "-qdpc=e"],
+	"CC": "mpicc",
 	"CFLAGS": ["-DMPIIO", "-Dr8", "-DMPI", "-DGLOBAL_LONG_LONG",
 		   "-DIBM", "-DPREFIX=jl_"],
-	"LD": "/bgsys/drivers/ppcfloor/comm/xl/bin/mpixlf77_r",
+	"LD": "mpif77",
 	"LDFLAGS": ["-L/soft/libraries/alcf/current/xl/LAPACK/lib",
                     "-llapack",
 	            "-L/soft/libraries/alcf/current/xl/BLAS/lib",

--- a/bin/configurenek
+++ b/bin/configurenek
@@ -101,7 +101,8 @@ def configure(FC, CC, LD, FFLAGS, CFLAGS, LDFLAGS):
     return FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS
 
 
-def write_makefile(app, usr, JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
+def write_makefile(app, usr, JL, FC, FFLAGS, CC, CFLAGS, JLFLAGS, LD,
+                   LDFLAGS):
     NEKBASE = os.path.join(NEK, 'src')
     nekfn = os.path.join(NEK, 'bin', 'Makefile.inc')
     fn = os.path.join(EXAMPLE, 'Makefile')
@@ -117,6 +118,8 @@ def write_makefile(app, usr, JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
                 line = line.replace('?LD?', 'LD = {0}'.format(LD))
                 line = line.replace('?LDFLAGS?',
                                     'LDFLAGS = {0}'.format(LDFLAGS))
+                line = line.replace('?JLFLAGS?',
+                                    'JLFLAGS = {0}'.format(JLFLAGS))
                 line = line.replace('?NEKBASE?',
                                     'NEKBASE = {0}'.format(NEKBASE))
                 line = line.replace('?JLBASE?', 'JLBASE = {0}'.format(JL))
@@ -163,21 +166,31 @@ def main():
         LDFLAGS += args.extra_LDFLAGS.split()
     app = args.app
     if app == 'maxwell':
-        FFLAGS.append('-DMAXWELL')
+        appflag = '-DMAXWELL'
     elif app == 'drift':
-        FFLAGS.append('-DDRIFT')
+        appflag = '-DDRIFT'
     elif app == 'schrod':
-        FFLAGS.append('-DSCHROD')
+        appflag = '-DSCHROD'
     else:
         raise ValueError('Invalid application')
+    # Hack to work around preprocessor macros being prefixed with -WF
+    # on IBM compilers.
+    if args.arch == 'blue-gene-q':
+        FFLAGS.append('-WF,' + appflag)
+        JLFLAGS = ['-DAMG_DUMP']
+    else:
+        FFLAGS.append(appflag)
+        JLFLAGS = ['-DAMG_DUMP', '-DGS_NEW_LOOPS']
     FFLAGS = ' '.join(FFLAGS)
     CFLAGS = ' '.join(CFLAGS)
+    JLFLAGS = ' '.join(JLFLAGS)
     LDFLAGS = ' '.join(LDFLAGS)
     if args.jl:
         JL = args.jl
     else:
         JL = os.path.join(NEK, 'src', 'jl')
-    write_makefile(app, usr, JL, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS)
+    write_makefile(app, usr, JL, FC, FFLAGS, CC, CFLAGS, JLFLAGS, LD,
+                   LDFLAGS)
 
 
 if __name__ == '__main__':

--- a/src/cem_drive.F
+++ b/src/cem_drive.F
@@ -375,6 +375,7 @@ c----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
+      include 'EMWAVE'
       include 'PML'
 
 #ifdef _OPENACC
@@ -459,6 +460,7 @@ c----------------------------------------------------------------------
       implicit none
       include 'SIZE'
       include 'TOTAL'
+      include 'EMWAVE'
       include 'PML'
 
 #ifdef _OPENACC

--- a/src/cem_maxwell.F
+++ b/src/cem_maxwell.F
@@ -2532,7 +2532,6 @@ c-----------------------------------------------------------------------
       implicit none
 
       include 'SIZE'
-      include 'WZ'
       logical if3d
       real u1r(lx1,ly1,lz1,lelt)
       real u1s(lx1,ly1,lz1,lelt)


### PR DESCRIPTION
- Make sure that `-DGS_NEW_LOOPS` isn't defined so that `gs_local.c`
  becomes an empty file and we don't hit any `_Pragma`s
- Make sure preprocessor options for the Fortran compiler get prefixed
   with the appropriate `-WF,`
- Don't give the full path to the compilers in `arch.json`; instead
   assume that the user has correctly used `softenv` to add the IBM
   compilers to their PATH.

Note that to correctly compile users should add `+python` and
`+mpiwrapper-xl` (or `+mpiwrapper-xl.ndebug`) to their `.soft` file.

Furthermore, although the code compiles again it has not yet been
checked for correctness since all the allocations I have access to
 have expired. The GPU tests **do** still pass on Tesla, however.
We'll see if by some miracle they also pass on Travis.

Ping people who wanted to run on Cetus/Mira (@misunmin, @yslan).