### PR TITLE
Fix intel compiler issue in `configurenek`

### DIFF
--- a/bin/configurenek
+++ b/bin/configurenek
@@ -84,7 +84,7 @@ def configure(FC, CC, LD, FFLAGS, CFLAGS, LDFLAGS):
         FFLAGS = ['-I.', '-O3', '-DMPI', '-DMPIIO']
         if 'GNU' in info:
             FFLAGS += ['-fdefault-real-8', '-fdefault-double-8']
-        elif 'INTEL' in info:
+        elif 'Intel' in info:
             FFLAGS += ['-r8']
         elif 'Portland' in info:
             FFLAGS += ['-r8']


### PR DESCRIPTION
The script should now work with intel compilers out of the
box. (i.e. there's no need to set `arch`.)