### PR TITLE
Prevent code from hanging in `genbox` when `lel?` is too small

### DIFF
--- a/src/nek5_genbox.F
+++ b/src/nek5_genbox.F
@@ -8,8 +8,10 @@ c
       character*132 string
       character*1  string1(132)
       equivalence (string,string1)
-C
-c
+      integer ierr
+
+      ierr = 0
+
       call blank (string,132)
 c     call gets  (string,132,iend,9) ! read name of "box" file from .rea file
 c     read (9,132) string       ! *** MESH?
@@ -49,10 +51,10 @@ c
              if (nid.eq.0) write(6,*) 'nfield > ldimt',nfield,ldimt
              call exitt(1)
          endif
-         call getbox(xgtp,ygtp,zgtp,nfld)  ! Read in the .box file
+         call getbox(xgtp,ygtp,zgtp,nfld,ierr) ! Read in the .box file
          close (unit=7)
-c
       endif
+      if (ierr.ne.0) call exitt(1)
 c
       call bcpbox(nfld)
 c
@@ -150,8 +152,13 @@ c
       return
       end
 c-----------------------------------------------------------------------
-      subroutine getbox(x,y,z,nfld)
+      subroutine getbox(x,y,z,nfld,ierr)
+c-----------------------------------------------------------------------
+c     Read in the box file.
 c
+c     Note: this subroutine only gets called from MPI rank 0, so if
+c     something goes wrong we can't call `exitt`. Instead return an
+c     error code in `ierr`.
       include 'SIZE'
       include 'INPUT'
       include 'ZPER'
@@ -161,8 +168,9 @@ c
       logical ifevenx,ifeveny,ifevenz,if_multi_seg
       character*1 boxcirc
 c
-      integer nelxyz(3)
-c
+      integer nelxyz(3),ierr
+
+      ierr = 0
       ifevenx = .false.
       ifeveny = .false.
       ifevenz = .false.
@@ -206,7 +214,8 @@ c
          if (nelx.gt.lelx.or.nely.gt.lely.or.nelz.gt.lelz) then
             write(6,*) 'Abort, increase lelx,..lelz and recompile',
      $                    nelx,nely,nelz,lelx,lely,lelz
-            call exitt(1)
+            ierr = 1
+            return
          endif
 c
          nery = nely
@@ -286,7 +295,8 @@ c
          if (nelx.gt.lelx.or.nely.gt.lely) then
             write(6,*) 'Abort, increase lelx,lely and recompile',
      $                    nelx,nely,lelx,lely
-            call exitt(1)
+            ierr = 1
+            return
          endif
 c
          nery = nely


### PR DESCRIPTION
Closes gh-34.