### PR TITLE
Allow for a proper installation of NekCEM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+prefix ?= /usr/local
+bindir ?= /usr/local/bin
+curdir = $(shell pwd)
+
+
+build:
+	@echo "Nothing to build; see README.md for details."
+
+install:
+	@mkdir -p $(DESTDIR)$(prefix)/NekCEM
+	@cp -r src $(DESTDIR)$(prefix)/NekCEM
+	@cp -r bin $(DESTDIR)$(prefix)/NekCEM
+	@mkdir -p $(DESTDIR)$(bindir)
+	@ln -s $(DESTDIR)$(prefix)/NekCEM/bin/configurenek $(DESTDIR)$(bindir)/configurenek
+	@ln -s $(DESTDIR)$(prefix)/NekCEM/bin/nek $(DESTDIR)$(bindir)/nek
+
+uninstall:
+	@unlink $(DESTDIR)$(bindir)/configurenek
+	@unlink $(DESTDIR)$(bindir)/nek
+	@rm -rf $(DESTDIR)$(prefix)/NekCEM
+
+install_inplace:
+	@ln -s $(curdir)/bin/configurenek $(DESTDIR)$(bindir)/configurenek
+	@ln -s $(curdir)/bin/nek $(DESTDIR)$(bindir)/nek
+
+uninstall_inplace:
+	@unlink $(DESTDIR)$(bindir)/configurenek
+	@unlink $(DESTDIR)$(bindir)/nek

--- a/bin/Makefile.inc
+++ b/bin/Makefile.inc
@@ -32,30 +32,30 @@ JLOBJ = $(patsubst $(JLBASE)/%.c, obj/%.o, $(JLSRC))
 USROBJ = obj/subuser.o
 
 
-obj/%.o : $(NEKBASE)/%.F SIZE
+obj/%.o: $(NEKBASE)/%.F SIZE
 	$(FC) -c $(FFLAGS) $< -o $@
 
-obj/%.o : $(NEKBASE)/%.c
+obj/%.o: $(NEKBASE)/%.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
-obj/%.o : $(JLBASE)/%.c
+obj/%.o: $(JLBASE)/%.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
-all : usr jl $(APPOBJ) $(FOBJ) $(COBJ) $(COMMOBJ)
+all: usr jl $(APPOBJ) $(FOBJ) $(COBJ) $(COMMOBJ)
 	$(LD) -o nekcem $(APPOBJ) $(FOBJ) $(COBJ) $(JLOBJ) $(USROBJ) \
 			$(COMMOBJ) $(LDFLAGS)
 
-usr : dir $(USR)
+usr: dir $(USR)
 	cp $(USR) obj/subuser.F
 	$(FC) -c obj/subuser.F -o $(USROBJ) $(FFLAGS) -I$(NEKBASE)
 	rm obj/subuser.F
 
-jl : dir $(JLOBJ)
+jl: dir $(JLOBJ)
 
-dir :
+dir:
 	@mkdir -p obj vtk
 
-clean :
+clean:
 	@rm -rf compiler.out nekcem vtk obj box.tmp
 	@rm -f *.output xxt_map.rea SESSION.NAME
 	@rm -f *.cobaltlog *.error logfile


### PR DESCRIPTION
Installation is done with `make install`. Our install is a little
abnormal since there is no code to compile, but there is still value
in copying `NekCEM/src` and `NekCEM/bin` to `/usr/local` and then
symlinking `configurenek` and `nek` to `/usr/local/bin` because then
`configurenek` and `nek` are on the user's PATH. Then on a typical
system the build process is just

- configurenek
- make
- mpiexec

For developers also allow for an "in place build" which just symlinks
`configurenek` and `nek` to the in-tree executables.