### PR TITLE
Add a restart test for Maxwell

### DIFF
--- a/src/io.F
+++ b/src/io.F
@@ -185,11 +185,7 @@ c...  dumpno for restarting case comes from previous step
              iparam7=0              !write io trace                       
          endif
          if (ifrestart) then
-            if (nid.eq.0) then
-             iparam4= param(84)+1   !restart dumpno update
-            else
-             iparam4= 0
-            endif
+            iparam4 = param(84) !restart dumpno update
          endif
 c...     iglsum is not doing smart bcast'ing, revert back to bcast -- jingfu
          call bcast(iparam1,isize)
@@ -238,7 +234,7 @@ c...  this produces output for (io-option=iparam) with timing info
          call vtk_nonswap_field( Qr(1,1),Qr(1,2),Qr(1,3),vtkout2)
          call vtk_nonswap_field( Qi(1,1),Qi(1,2),Qi(1,3),vtkout3)
          call vtk_nonswap_field( sUr,sQr(1,1),sQi(1,1),vtkout4)
-#elif defined DRIFT 
+#elif defined DRIFT
          !FIXME: restr DRIFT, Lan
          call vtk_nonswap_field(cN(1,1),cN(1,2),potent,vtkout1)
          call vtk_nonswap_field(scN(1,1),scN(1,2),spotent,vtkout2)
@@ -271,7 +267,7 @@ c...     maybe need a thread_join function to ensure the last io step finished
 c...  produce restart files
          if (irestart.gt.0) then !io-frequency for restart files >= nonzero
 
-          if (mod(istep,irestart*iostep).eq.0) then
+            if (mod(istep,irestart*iostep).eq.0) then
 
 #ifdef NO_MPI
            write(6,*) 'non-mpi run: no restart file produced'

--- a/tests/restart/SIZE
+++ b/tests/restart/SIZE
@@ -1,0 +1,181 @@
+c     Dimension file to be included
+c
+c     HCUBE array dimensions
+
+      integer    ldim, lxi, lx1, ly1, lz1, lelv, lelt, lp, lelg
+      integer    lxs, lys, lzs, lgmres,lfdm
+      parameter (ldim=  2)
+      parameter (lxi =  8)  ! polynomial order
+      parameter (lx1 =lxi+1,ly1=lxi+1,lz1=1+lxi*(ldim-2))
+      parameter (lelv= 16, lelt=lelv)
+      parameter (lp  = 8)
+      parameter (lelg= 16)
+      parameter (lxs=1,lys=lxs,lzs=(lxs-1)*(ldim-2)+1)
+      parameter (lgmres =  1)
+      parameter (lfdm= 0)  !global fast diagonalization method (1=on; 0=off)
+
+c     Choose meshes: if mesh=0 (hex/quad), if mesh=1 (tet/tri)
+c     Build  basis : DG (default), if nedelec=1 (nedelec)
+      integer    mesh, nedelec
+      parameter (mesh    = 0)
+      parameter (nedelec = 0)
+
+c     Arrays for new GEOM in TMPINPUT: temporary
+      integer    lpts,lxzfl,lxyzm
+      parameter (lpts = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl= lx1*lz1*2*ldim*lelt)
+      parameter (lxyzm= lx1*ly1*lz1        )
+
+c     Assign different size for different solvers
+      integer    lpts1,lxzfl1,lpts2,lxzfl2,lpts3,lxzfl3,lpts4,lxzfl4
+      integer    lpts5,lxzfl5,lfp,lxd,lyd,lzd
+      integer    lpts10,lxzfl10
+
+c     Arrays for Maxwell solver
+      parameter (lpts1 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl1= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Drude/Lorentz/Hydraulic Models with Maxwell
+      parameter (lpts10 = lpts1 )
+      parameter (lxzfl10= lxzfl1)
+
+c     Arrays for Schrodinger solver
+      parameter (lpts2 = 1) !(lpts2= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl2= 1) !(lxzfl2= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Acoustic solver
+      parameter (lpts3 = 1) !(lpts3= lx1*ly1*lz1*lelt   )
+      parameter (lxzfl3= 1) !(lxzfl3= lx1*lz1*2*ldim*lelt)
+      parameter (lfp   = 1) ! fourier points for DtN operator
+
+c     Arrays for Drift-Diffusion solver
+      parameter (lpts4 = lx1*ly1*lz1*lelt   )
+      parameter (lxzfl4= lx1*lz1*2*ldim*lelt)
+
+c     Arrays for Nedelec solver
+      parameter (lxd   =lx1,lyd=ly1,lzd=lz1)
+      parameter (lpts5 =1)! lxd*lyd*lzd*lelt   )
+      parameter (lxzfl5=1)! lxd*lzd*2*ldim*lelt)
+
+c     Arrays for Eigenvalue calculations: when not using set it as 1
+      integer    lpts_eig
+      parameter (lpts_eig= 1) ! (lpts_eig =lx1*ly1*lz1*lelt*2*ldim)
+
+c     Arrays for Quantum Model calculations
+      integer    level,lnumqd,lnumsp,lstate,lrho,leqn,lEh
+      parameter (level   = 1      )       ! number of qd states
+      parameter (lnumqd  = 1      )       ! number of surface plasmon states
+      parameter (lnumsp  = 1      )       ! number of surface plasmon states
+      parameter (lstate  = level**lnumqd*lnumsp)   ! number of total states
+      parameter (lrho    = lstate*lstate) ! number of rho
+      parameter (leqn    = 1      )       ! number of eqns: real/imag
+      parameter (lEh     = 1      )       ! number of energy
+
+c     Exponential Integrator
+      integer    larnol,luniform,levg,lelg2d,lmov,lw
+      parameter (larnol  = 1)
+      parameter (luniform= 1)
+      parameter (levg    = 1)
+      parameter (lelg2d  = 9)
+      parameter (lmov    = 0)
+      parameter (lw      = 5)
+
+c     Interpolation: lpart = the number of points for interpolation
+      integer    lpart
+      parameter (lpart= 1)
+
+c     Arrays for .box mesh
+      integer    lelx , lely , lelz
+      integer    lpelv, lpelt, lpert
+      integer    lpx1 , lpy1 , lpz1
+      integer    lpx2 , lpy2 , lpz2
+      integer    lbelt, lbelv
+      integer    lbx1 , lby1 , lbz1
+      integer    lbx2 , lby2 , lbz2
+      parameter (lelx =5,lely =lelx ,lelz =lelx )
+      parameter (lpelv=1,lpelt=lpelv,lpert=lpelv)
+      parameter (lpx1 =1,lpy1 =lpx1 ,lpz1 =lpx1 )
+      parameter (lpx2 =1,lpy2 =lpx2 ,lpz2 =lpx2 )
+      parameter (lbelv=lelv, lbelt=lelv )
+      parameter (lbx1 =1,lby1 =lbx1 ,lbz1 =lbx1 )
+      parameter (lbx2 =1,lby2 =lbx2 ,lbz2 =lbx2 )
+
+      integer    lzl
+      integer    lx2, ly2, lz2
+      integer    lx3, ly3, lz3
+      integer    lx1m, ly1m, lz1m
+      integer    ldimt, ldimt1, ldimt3
+
+      PARAMETER (LZL=1+2*(ldim-2))
+      PARAMETER (LX2=LX1)
+      PARAMETER (LY2=LY1)
+      PARAMETER (LZ2=LZ1-2*(ldim-2))
+      PARAMETER (LX3=LX1)
+      PARAMETER (LY3=LY1)
+      PARAMETER (LZ3=LZ1)
+
+C     LX1M=LX1 when there are moving meshes; =1 otherwise
+      PARAMETER (LX1M  =1,LY1M=1,LZ1M=1)
+      PARAMETER (LDIMT = 1)
+      PARAMETER (LDIMT1=LDIMT+1)
+      PARAMETER (LDIMT3=LDIMT+3)
+
+c
+c     Note:  In the new code, LELGEC should be about sqrt(LELG)
+c
+      integer    lelgec, lxyz2, lxz21
+      PARAMETER (LELGEC = 1)
+      PARAMETER (LXYZ2  = 1)
+      PARAMETER (LXZ21  = 1)
+c
+c     integer    lmaxv, lmaxt, lmaxp
+      integer    lxz, lorder, maxobj, maxmbr
+c     PARAMETER (LMAXV=LX1*LY1*LZ1*LELV)
+c     PARAMETER (LMAXT=LX1*LY1*LZ1*LELT)
+c     PARAMETER (LMAXP=LX2*LY2*LZ2*LELV)
+      PARAMETER (LXZ=LX1*LZ1)
+      PARAMETER (LORDER=3)
+      PARAMETER (MAXOBJ=2,MAXMBR=LELT*6)
+C
+C     Common Block Dimensions
+C
+      integer    lctmp0, lctmp1
+      PARAMETER (LCTMP0 =2*LX1*LY1*LZ1*LELT)
+      PARAMETER (LCTMP1 =4*LX1*LY1*LZ1*LELT)
+C
+C     The parameter LVEC controls whether an additional 42 field arrays
+C     are required for Steady State Solutions.  If you are not using
+C     Steady State, it is recommended that LVEC=1.
+C
+      integer    lvec
+      PARAMETER (LVEC=1)
+C
+C     Uzawa projection array dimensions
+C
+c     PARAMETER (MXPREV = 01)
+C
+C     Split projection array dimensions
+C
+      integer    lmvec, lsvec, lstore
+      parameter (lmvec = 1)
+      parameter (lsvec = 1)
+      parameter (lstore=lmvec*lsvec)
+c
+c     NONCONFORMING STUFF
+c
+      integer    maxmor
+      parameter (maxmor = lelt)
+C
+C     Array dimensions
+C
+      integer    nelv, nelt
+      integer    nx1, ny1, nz1
+      integer    nx2, ny2, nz2
+      integer    nx3, ny3, nz3
+      integer    ndim, nfield, nid, npert
+      integer    nxyz, npts, nxzf, nxzfl, nfaces
+
+      COMMON /DIMN/
+     $           NELV,NELT,NX1,NY1,NZ1,NX2,NY2,NZ2
+     $          ,NX3,NY3,NZ3,NDIM,NFIELD,NID,NPERT
+     $          ,NXYZ,NPTS,NXZF,NXZFL,NFACES

--- a/tests/restart/restart.box
+++ b/tests/restart/restart.box
@@ -1,0 +1,14 @@
+restart.rea
+2
+1                      number of fields
+#
+#    comments
+#
+#
+#========================================================
+#
+Box
+-4  -4  (number of elements in x,y)
+-1500  1500   1              (x0,x1,gain)
+-1500  1500   1              (x0,x1,gain)
+P  ,P  ,P  ,P                (bc's)

--- a/tests/restart/restart.rea
+++ b/tests/restart/restart.rea
@@ -1,0 +1,163 @@
+ ****** PARAMETERS *****
+    2.610000     NEKTON VERSION
+2 DIMENSIONAL RUN
+103 PARAMETERS FOLLOW
+  0                             1: ---
+  0                             2: ---
+  0                             3: ---
+  1                             4: ifte (1), iftm (2)
+  0                             5: IFSCHROD=10,11,...; IFDRIFT=20,21,....,29(DG); IFDRIFT=30(w/o exciton),31(w/ exciton),39(SEM);
+  0                             6: source turn on (1); turn off (0)
+  0                             7: inhomogeneous boundary turn on (1)
+  1                             8: # of field (default=0)
+  0                             9: ---
+  0.0                           10: fintim: final time if positive; overrides nsteps. Ignored if negative.
+  0                             11: nsteps: total number of timesteps
+  0.2                           12: dt: timestep size if negative, eg. -0.05; CFL number if positive, eg. CFL = 0.2
+  100                           13: iocomm: frequency of print statements
+  0.000000E+00                  14: ---
+  1                             15: iostep: frequency of vtk writes
+  1                             16: ifsol: 1 if solution is assigned, 0 if not
+  0                             17: Timestep: 10(EIG),0 or 45(RK45),44(rk44),33(rk33),22(rk22), 1(EXP), -1(BDF1), -2(BDF2)
+  0                             18: Filter: 0 (no filter), 1 (turn on filter), Dealias: -1 (turn on dealias)
+  0                             19: FLUXES: 0 (upwind flux), 1 (central flux)
+  5.00000                       20: ORDER (MESH): positive value
+  0                             21: define poisson solver --> GMRES(1), CG(2), GMRES-SEMG(3); negative sign w/ projection GMRES(-1), CG(-2), GMRES-SEMG(-3)
+  0                             22: tolerance      : (GMRES, CG, GMRES-SEMG)
+  0                             23: preconditioner : FDM for CG(1)
+  0                             24: define unsteady time dependent solver --> GMRES(1), CG(2); negative sign w/ projection GMRES(-1), CG(-2)
+  0                             25: drift-diffusion GFDM (global fast diagonalization): GFDMDD (1)
+  0                             26: ---
+  3.00000                       27: TORDER
+  0.000000E+00                  28: TMESH
+  0.000000E+00                  29: ---
+  0.000000E+00                  30: ---
+  0.000000E+00                  31: ---
+  0.000000E+00                  32: ---
+  0                             33: ---
+  0                             34: ---
+  0                             35: ---
+  0                             36: ---
+  0                             37: ---
+  0.000000E+00                  38: ---
+  0.000000E+00                  39: ---
+  0.000000E+00                  40: ---
+  0.000000E+00                  41: ---
+  0.000000E+00                  42: ---
+  0                             43: ---
+  0.000000E+00                  44: ---
+  0.000000E+00                  45: ---
+  0.000000E+00                  46: ---
+  0.000000E+00                  47: ---
+  0.000000E+00                  48: ---
+  0.140000                      49: ---
+  0.000000E+00                  50: ---
+  0.000000E+00                  51: ---
+  0.000000E+00                  52: ---
+  0.000000E+00                  53: ---
+  0.000000E+00                  54: ---
+  0.000000E+00                  55: ---
+  0.000000E+00                  56: ---
+  0                             57: ---
+  0                             58: ---
+  0                             59: ---
+  0                             60: ---
+  0                             61: ---
+  0                             62: ---
+  0                             63: ---
+  0                             64: ---
+  0                             65: ---
+  0                             66: ---
+  0                             67: ---
+  0                             68: ---
+  0                             69: ---
+  0                             70: ---
+  0                             71: ---
+  0                             72: ---
+  0                             73: ---
+  0                             74: ---
+  0                             75: ---
+  0                             76: ---
+  6.000000E+00                  77: PMLTHICK : thickness of the PML in levels
+  3.000000E+00                  78: PMLORDER : polynomial order of the grading of the PML parameter sigma
+  1e-15                         79: PMLREFERR : PML reflection error
+  4                             80: I/O: total (exact) number of output fields: currently default=4
+  4                             81: I/O: 0 (no output), 1 (fld),2 (posix ascii),3 (posix binary), 4,5, (coIO), 6,-6,8 (rbIO)
+  1                             82: I/O: the number of outputfiles per timestep
+  1                             83: I/O: frequency of restart output files, 0 (no restart output), #nn (iostep*nn)
+  1                             84: RESTART (should be 0 for non-mpi run): invoked with dump_number from the name of the restarting output file
+  0                             85: computation trace active if positive number
+  0                             86: io trace active if positive number
+  0                             87: I/O: "1" on BGP ;if >0, write/read restart files in float; if 0 (=default), double
+  0                             88: ---
+  0                             89: ---
+  0                             90: ---
+  0                             91: ---
+  0                             92: ---
+  0                             93: ifstdh: for drift-diffusion
+  0                             94: p945: for drift-diffusion
+  0                             95: p945: for drift-diffusion
+  0                             96: ---
+  0                             97: ---
+  0                             98: ---
+  0                             99: ---
+  0                             100: ---
+  0                             101: ---
+  0                             102: ---
+  0                             103: ---
+			4  Lines of passive scalar data follows2 CONDUCT; 2RHOCP
+   1.00000       1.00000       1.00000       1.00000       1.00000
+   1.00000       1.00000       1.00000       1.00000
+   1.00000       1.00000       1.00000       1.00000       1.00000
+   1.00000       1.00000       1.00000       1.00000
+13 LOGICAL SWITCHES FOLLOW
+  F                             1: IFFLOW
+  T                             2: IFHEAT
+  T                             3: IFTRAN
+  F                             4: IFSRC
+  T                             5: IFCENTRAL
+  F                             6: IFUPWIND
+  F                             7: IFTM (2D only)
+  T                             8: IFTE (2D only)
+  F                             9: IFDEALIAS
+  F                             10: IFRK4
+  T                             11: IFEXP
+  F                             12: IFEIG
+  F                             13: IFNM
+  9.23077       9.23077      -4.38462      -5.30769     XFAC,YFAC,XZERO,YZERO
+ **MESH DATA** 1st line is X of corner 1,2,3,4. 2nd line is Y.
+    9     -2     9          NEL,NDIM,NELV
+restart.box
+            0 PRESOLVE/RESTART OPTIONS  *****
+            7         INITIAL CONDITIONS *****
+C Default
+C Default
+C Default
+C Default
+C Default
+C Default
+C Default
+  ***** DRIVE FORCE DATA ***** BODY FORCE, FLOW, Q
+            4                 Lines of Drive force data follow
+C
+C
+C
+C
+  ***** Variable Property Data ***** Overrrides Parameter data.
+            1 Lines follow.
+            0 PACKETS OF DATA FOLLOW
+  ***** HISTORY AND INTEGRAL DATA *****
+            0   POINTS.  Hcode, I,J,H,IEL
+  ***** OUTPUT FIELD SPECIFICATION *****
+            6 SPECIFICATIONS FOLLOW
+  F      COORDINATES
+  F      VELOCITY
+  F      PRESSURE
+  T      TEMPERATURE
+  F      TEMPERATURE GRADIENT
+            0      PASSIVE SCALARS
+  ***** OBJECT SPECIFICATION *****
+       0 Surface Objects
+       0 Volume  Objects
+       0 Edge    Objects
+       0 Point   Objects

--- a/tests/restart/restart.usr
+++ b/tests/restart/restart.usr
@@ -1,0 +1,168 @@
+c-----------------------------------------------------------------------
+c
+c     Box geometry with periodic boundary conditions.
+c
+c-----------------------------------------------------------------------
+      subroutine userinc(tt,incfhx,incfhy,incfhz,incfex,incfey,incfez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real incfhx(lxzfl),incfhy(lxzfl),incfhz(lxzfl)
+      real incfex(lxzfl),incfey(lxzfl),incfez(lxzfl)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userini(tt,hx,hy,hz,ex,ey,ez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+
+      real tt
+      real hx(lpts),hy(lpts),hz(lpts)
+      real ex(lpts),ey(lpts),ez(lpts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersol(tt,solhx,solhy,solhz,solex,soley,solez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+      real tt
+      real solhx(lpts),solhy(lpts),solhz(lpts)
+      real solex(lpts),soley(lpts),solez(lpts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usersrc(tt,srchx,srchy,srchz,srcex,srcey,srcez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real srchx(lpts),srchy(lpts),srchz(lpts)
+      real srcex(lpts),srcey(lpts),srcez(lpts)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userfsrc(tt,srcfhx,srcfhy,srcfhz,srcfex,srcfey,srcfez)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+
+      real tt
+      real srcfhx(lxzfl),srcfhy(lxzfl),srcfhz(lxzfl)
+      real srcfex(lxzfl),srcfey(lxzfl),srcfez(lxzfl)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine uservp(ix,iy,iz,iel)
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+c     These don't do anything! This is a temporary measure until
+c
+c     https://github.com/NekCEM/NekCEM/issues/12
+c
+c     is resolved.
+      integer ix,iy,iz,iel
+
+      integer i
+
+      do i = 1,npts
+         permittivity(i) = 1.0
+         permeability(i) = 1.0
+      enddo
+
+c     Fill the E/H fields with 1.0 and write that to a vtk file.
+      do i = 1,npts
+         hn(i,1) = 1.0
+         hn(i,2) = 1.0
+         hn(i,3) = 1.0
+         en(i,1) = 1.0
+         en(i,2) = 1.0
+         en(i,3) = 1.0
+      enddo
+      call cem_out
+
+c     Now fill the fields with 2.0; if restart is working then when we
+c     get to the first `userchk` then everything should still be filled
+c     with 1.0.
+      do i = 1,npts
+         hn(i,1) = 2.0
+         hn(i,2) = 2.0
+         hn(i,3) = 2.0
+         en(i,1) = 2.0
+         en(i,2) = 2.0
+         en(i,3) = 2.0
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat
+c-----------------------------------------------------------------------
+      implicit none
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine usrdat2
+c-----------------------------------------------------------------------
+      implicit none
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine userchk
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'EMWAVE'
+
+      integer i
+      real l2(6),linf(6)
+
+      do i = 1,npts
+         shn(i,1) = 1.0
+         shn(i,2) = 1.0
+         shn(i,3) = 1.0
+         sen(i,1) = 1.0
+         sen(i,2) = 1.0
+         sen(i,3) = 1.0
+      enddo
+
+      call cem_error(hn(1,1),shn(1,1),errhn(1,1),npts,l2(1),linf(1))
+      call cem_error(hn(1,2),shn(1,2),errhn(1,2),npts,l2(2),linf(2))
+      call cem_error(hn(1,3),shn(1,3),errhn(1,3),npts,l2(3),linf(3))
+      call cem_error(en(1,1),sen(1,1),erren(1,1),npts,l2(4),linf(4))
+      call cem_error(en(1,2),sen(1,2),erren(1,2),npts,l2(5),linf(5))
+      call cem_error(en(1,3),sen(1,3),erren(1,3),npts,l2(6),linf(6))
+
+      do i = 1,6
+         if (l2(i).gt.1e-15) then
+            write(*,*) 'ERROR: restart failed'
+            call exitt(1)
+         elseif (linf(i).gt.1e-15) then
+            write(*,*) 'ERROR: restart failed'
+            call exitt(1)
+         endif
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -79,6 +79,14 @@
 	"params": {"4": 2, "70": 1},
 	"parallelization": ["mpi", "acc"]
     },
+    "maxwell-restart": {
+	"app": "maxwell",
+	"dir": "restart",
+	"usr": "restart",
+	"rea": "restart",
+	"params": {},
+	"parallelization": ["mpi"]
+    },
     "poisson-2dpec": {
         "app": "maxwell",
         "dir": "poisson2d",


### PR DESCRIPTION
The test is somewhat hacky. It:

- Initializes the E and H fields in `uservp` and then writes them to a
  vtk
- Changes the values in the E and H fields
- Sets `ifrestart` to be true so that the just-written restart file
  is read
- Checks that the E and H fields have the original values

~~This required allowing the IO code to read a restart value at time
step 0, which should not be a problem.~~