### PR TITLE
Change the argument order

### DIFF
--- a/bin/configurenek
+++ b/bin/configurenek
@@ -92,7 +92,7 @@ def check_FC_compiler(FC, flags):
     return compiler
 
 
-def configure(FC, CC, LD, FFLAGS, CFLAGS, LDFLAGS):
+def configure(FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
     if FC:
         compilers = [FC]
     else:


### PR DESCRIPTION
In the current development branch, configure function is defined as follows:
```python
def configure(FC, CC, LD, FFLAGS, CFLAGS, LDFLAGS):
```
But it is called as follows:
```python
config = configure(args.FC, args.FFLAGS,
                   args.CC, args.CFLAGS,
                   args.LD, args.LDFLAGS)
```
I think the orders don't match. This PR fixes this order. 
@misunmin , @person142 : Can you please review this?