### PR TITLE
Fix bug with passing FFLAGS, CFLAGS, and LDFLAGS in `configurenek`

### DIFF
--- a/bin/configurenek
+++ b/bin/configurenek
@@ -125,6 +125,9 @@ def configure(FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
                        '-qdpc=e']
         else:
             raise Exception("Shouldn't be able to get here!")
+    else:
+        FFLAGS = FFLAGS.split()
+
     if not CFLAGS:
         CFLAGS = ['-O3', '-DMPIIO', '-DMPI', '-DGLOBAL_LONG_LONG',
                   '-DAMG_DUMP']
@@ -138,6 +141,9 @@ def configure(FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
             CFLAGS += ['-Dr8', '-DIBM', '-DPREFIX=jl_']
         else:
             raise Exception("Shouldn't be able to get here!")
+    else:
+        CFLAGS = CFLAGS.split()
+
     if not LDFLAGS:
         if backend == 'ifort' or backend == 'pgfortran':
             LDFLAGS = ['-lblas', '-llapack']
@@ -157,6 +163,8 @@ def configure(FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS):
             LDFLAGS += ['-llapack', '-lblas']
         else:
             raise Exception("Shouldn't be able to get here")
+    else:
+        LDFLAGS = LDFLAGS.split()
 
     return backend, FC, FFLAGS, CC, CFLAGS, LD, LDFLAGS
 


### PR DESCRIPTION
Closes gh-200.

@thilinarmtb could you check whether this fixes your problem? Now

```
configurenek maxwell 2dboxper --LDFLAGS="-L/home/thilina/Repos/CEED/spack/opt/spack/linux-ubuntu17.10-x86_64/gcc-6.4.0/openblas-0.2.20-tzh6zl6jyufvohifypayse5ujxovvmx7/lib -lopenblas"
```

gives me

```
LDFLAGS = -L/home/thilina/Repos/CEED/spack/opt/spack/linux-ubuntu17.10-x86_64/gcc-6.4.0/openblas-0.2.20-tzh6zl6jyufvohifypayse5ujxovvmx7/lib -lopenblas
```

in the makefile.