### PR TITLE
Fix `arch.json` for tesla

### DIFF
--- a/bin/arch.json
+++ b/bin/arch.json
@@ -66,7 +66,7 @@
     },
     "tesla-pgi-acc": {
         "FC": "mpif90",
-	"FFLAGS": ["-I.", "-acc", "-Minfo=accel",
+	"FFLAGS": ["-I.", "-acc", "-Minfo=accel", "-DMPI",
 	           "-ta=tesla:cc50,cuda8.0", "-DMPIIO", "-O3", "-r8"],
 	"CC": "mpicc",
 	"CFLAGS": ["-I.", "-acc", "-Minfo=accel",


### PR DESCRIPTION
Currently some of the tests fail on IO because the MPI IO code is `ifdef`ed and we didn't have the `-DMPI` flag set.