### PR TITLE
Add fully-coupled Newton mode and fix the order of f and g

### DIFF
--- a/src/NEWTON
+++ b/src/NEWTON
@@ -11,6 +11,7 @@ c=====================================================================
      $     jaceps,         ! perturbation parameter for Jacobi-free
      $     dt_const,       ! constant c for the formula dt = c * dtNT
      $     tolNT,          ! tolerance for Newton method
+     $     tolNTstep,      ! tolerance for Newton method by the update step size
      $     max_dtNT,       ! Max. of dtNT, avoid NaN
      $     min_ftol,       ! Min. of tol,  avoid NaN
      $     max_dt,         ! Max. of dt, satisfying CFL
@@ -19,7 +20,7 @@ c=====================================================================
      $     inexactNT(lcdim)
       real dtNT
      $    ,alphaNT,jaceps,dt_const
-     $    ,tolNT,max_dtNT,min_ftol,max_dt
+     $    ,tolNT,tolNTstep,max_dtNT,min_ftol,max_dt
      $    ,f_pre,f_now,inexactNT
 
       common /newton_parami/

--- a/src/NMGMRES
+++ b/src/NMGMRES
@@ -1,0 +1,19 @@
+c     parameter (lgmres=50) !max number of gmres iterations between restarts
+      common /gmresNT_fc/  x_NT(lx1*ly1*lz1*lelv,LDIMT-1)
+     $              , r_NT(lx1*ly1*lz1*lelv,LDIMT-1)
+     $              , w_NT(lx1*ly1*lz1*lelv,LDIMT-1)
+     $              , h_NT(lgmres,lgmres), gamma_NT(lgmres+1)
+     $              , c_NT(lgmres), s_NT(lgmres)
+      common /gmreNT1_fc/  v_NT(lx1*ly1*lz1*lelv,LDIMT-1,lgmres)
+      common /gmreNT2_fc/  z_NT(lx1*ly1*lz1*lelv,LDIMT-1,lgmres)
+      real x_NT,r_NT,w_NT,h_NT,gamma_NT,c_NT,s_NT,v_NT,z_NT
+
+c      common /spltprecNT/ ml_NT(lx1*ly1*lz1*lelv)
+c     $              ,     mu_NT(lx1*ly1*lz1*lelv)
+c      real ml_NT,mu_NT
+      
+c     w is a work vector
+c     c and s store the Givens rotations
+c     V stores the orthogonal Krylov subspace basis
+c          -1
+c     Z = M   V

--- a/src/cem_drift_newton.F
+++ b/src/cem_drift_newton.F
@@ -36,19 +36,20 @@ c     Set default ParamNT
         dtNT = param(1)      ! pseudo-transient time step
                              ! it can grow as istep increase 
 
-        ifsep     = 1        ! 0=couple, 1=separate, Lan
+        ifsep     = -1       ! -1=fully couple, 0=couple, 1=separate
         inexactNT_flag = 0   ! 0: fixed 0.1  1: r/r_pre  2: abs(r-res)/r_pre
         dt_flag   = 0        ! 0: fixed dt  1: dt = const * dtNT
         dtNT_flag = 2        ! 1: dtNT=c*dtNT  2:SER  -2:SER + constraint
 
         alphaNT   = 1.0      ! relaxation parameter of NT solver \alpha \in (0,1]
-        jaceps    = 1e-5     ! perturbation parameter for Jacobi-free
+        jaceps    = 1e-9     ! perturbation parameter for Jacobi-free
         dt_const  = 1E-4     ! constant c for the formula dt = c * dtNT
                              ! c = 1, 0.1, 0.01, 0.001, 0.0001
                              ! c = 0.0001 is the best case up to now
 
-        tolNT     = 1e-5     ! tolerance for Newton method
-        max_dtNT  = 1E5      ! Max. of dtNT, avoid NaN
+        tolNT     = 1e-10     ! tolerance for Newton method
+        tolNTstep = 1e-9     ! to avoid NT loop stalling
+        max_dtNT  = 1E12      ! Max. of dtNT, avoid NaN
         min_ftol  = 1E-12    ! Min. of f norm, avoid NaN
         max_dt    = 1E-1     ! Max. of dt, should be satisfied CFL
 
@@ -74,7 +75,12 @@ c-----------------------------------------------------------------------
       real rnorm,rnorms(lcdim),rnorms_pre(lcdim),res_gmres(lcdim)
       real rinorm,rinorms(lcdim),ratio
       real fnorm,fnorms(lcdim)
+      real norms_sk(lcdim),norms_ck0(lcdim),sk_ratio(lcdim),NTstep_norm
       real temp(lpts1)
+
+      real l2(6),linf(6) ! move userchk ot here
+      real dummy(lx1*ly1*lz1*lelt)
+      real cN_tmp(lx1*ly1*lz1*lelt,lcdim)
 
       integer i,j,k,n,ic
 
@@ -120,7 +126,6 @@ c     the initial step
 
       if (nsteps.eq.0) call cem_end
 
-
 c     compute initials
       epsinv = 1./jaceps   ! eps for approximation for jacobian
 
@@ -134,10 +139,6 @@ c     compute initials
       enddo
 
       call compute_f_couple(fn,cn_k,npts)
-      call compute_gk(gn_n,fn,cn_k,c_k0,npts) ! compute rhs g_k for GMRES
-      do ic = 1,lcdim
-        call chsign (gn_n(1,ic),npts)
-      enddo
 
       do ic = 1,lcdim
         fnorms(ic) = glsc3(fn(1,ic),fn(1,ic),mult,npts)
@@ -157,21 +158,31 @@ c     Start pseudo-time step
 
         cpu_dtime = dclock()
 
-c       determine dtNT, dt
-        if ((istep .eq. 1)) then
-          dtNT = param(1)
+c       Update dtNT, dt
+        if (istep.eq.1) then 
+          ! do nothing
         else
           call get_dtNT(dtNT,max_dtNT,f_pre,f_now,min_ftol,dtNT_flag)
+          call get_dt(dt,max_dt,dtNT,dt_const,dt_flag)
         endif
         dtNTinv = 1./dtNT
-
-        call compute_cfl(npts)
-        call get_dt(dt,max_dt,dtNT,dt_const,dt_flag)
         dtinv = 1./dt
 
+        call compute_cfl(npts) ! moniter only
+
+c       Update f and g
+        if (dt_flag.ne.0) call compute_f_couple(fn,c_k0,npts) ! update f_k0 if dt changed
+        call compute_gk(gn_n,fn,cn_k,c_k0,npts) ! compute rhs g_k for GMRES
+        do ic = 1,lcdim
+          call chsign (gn_n(1,ic),npts)
+        enddo
 
 c       Start Newton iteration
         do iterNT=1,maxit
+
+          do ic = 1,lcdim
+            norms_ck0(ic) = glsc3(c_k0(1,ic),c_k0(1,ic),mult,npts)
+          enddo
 
 c         determine inexactNT
           do ic = 1,lcdim
@@ -182,6 +193,10 @@ c         determine inexactNT
           if (ifsteric) then
 c            call drift_hmh_gmres_NTsteric(sn_k,gn_n,cn_k,fn
 c     $           ,mult,lcdim,npts,tolGMRES)
+          elseif (ifsep.eq.-1) then
+            call drift_hmh_gmres_newton_fc
+     $           (sn_k,gn_n,cn_k,fn,mult,lcdim,npts,res_gmres(1)
+     $           ,inexactNT(1))
           else
             do ic = 1,lcdim
               call drift_hmh_gmres_newton(sn_k(1,ic),gn_n(1,ic)
@@ -207,22 +222,35 @@ c     $           ,mult,lcdim,npts,tolGMRES)
           if (iterNT.eq.1) rinorm=rnorm
           ratio=rnorm/rinorm 
 
-          if ((nid.eq.0).and.(mod(istep,iocomm).eq.0)) write(6,90)
-     $       istep,iterNT,ratio,rnorm,rinorm,dtNT,dt
+c         check rel. update step size of NT to avoid stalling
+          do ic = 1,lcdim
+            norms_sk(ic) = glsc3(sn_k(1,ic),sn_k(1,ic),mult,npts)
+            sk_ratio(ic) = norms_sk(ic) / norms_ck0(ic)
+          enddo
+          NTstep_norm = glmax(sk_ratio,lcdim)
 
-          if (ratio.lt.tolNT) goto 900
+          if ((nid.eq.0).and.(mod(istep,iocomm).eq.0)) write(6,90)
+     $       istep,iterNT,ratio,rnorm,rinorm,dtNT,dt,NTstep_norm
+
+c          measure error for each Newton Loop, Lan
+c          do ic = 1,lcdim
+c            call copy(cN(1,ic),cn_k(1,ic),npts) ! for userchk
+c          enddo
+cc          call userchk
+c          call usersol(time,spotent,scn,dummy,dummy,dummy,dummy)
+c          call cem_error(cN(1,1),scN(1,1),errcN(1,1),npts,l2(1),linf(1))
+c          call cem_error(cN(1,2),scN(1,2),errcN(1,2),npts,l2(2),linf(2))
+c          call cem_error(potent,spotent,epotent,npts,l2(4),linf(4))
+c          if ((nid.eq.0).and.(mod(istep,iocomm).eq.0)) write(6,93)
+c     $       istep,iterNT,linf(1),linf(2),linf(4),dtNT,dt
+
+          if ((ratio.lt.tolNT).OR.(NTstep_norm.lt.tolNTstep)) goto 900
 c          if (rnorm.lt.new_tol) goto 900
 
         enddo
- 90     format('newton iter',2i6,1p5e12.4)   
+ 90     format('newton iter',2i6,1p6e12.4)   
+ 93     format('newton iter err cN',2i6,1p5e12.4)
 900     continue
-
-        do ic = 1,lcdim
-          call copy(c_k0(1,ic),cn_k(1,ic),npts)   ! update c_k0 for compute gn
-        enddo                           ! for next pseudo-time step
-        do ic = 1,lcdim
-          call copy(cN(1,ic),cn_k(1,ic),npts) ! just for cem_out
-        enddo
 
 c       compute the norm of f(c_p)^{istep-1} and f(c_n)^{istep-1}
         do ic = 1,lcdim
@@ -233,13 +261,12 @@ c       compute the norm of f(c_p)^{istep-1} and f(c_n)^{istep-1}
         f_pre = f_now  ! set up old fnorm to f_pre
         f_now = fnorm  ! set up new fnorm to f_now
 
-c       compute the CPU_time
-        cpu_dtime = dclock()-cpu_dtime
-        cpu_t = cpu_t+cpu_dtime
-        cpu_t_step = cpu_t/istep
-        cpu_p_t = glsum(cpu_t_step /npts,1)/np
-        
-        time = time + dtNT
+        do ic = 1,lcdim
+          call copy(c_k0(1,ic),cn_k(1,ic),npts)   ! update c_k0 for compute gn
+        enddo                           ! for next pseudo-time step
+        do ic = 1,lcdim
+          call copy(cN(1,ic),cn_k(1,ic),npts) ! just for cem_out
+        enddo
     
 c        call compute_energy
 
@@ -248,6 +275,13 @@ c        call compute_energy
         cpu_chk = dclock()-cpu_chk
 
         call cem_out
+
+
+c       compute the CPU_time
+        cpu_dtime = dclock()-cpu_dtime
+        cpu_t = cpu_t+cpu_dtime
+        cpu_t_step = cpu_t/istep
+        cpu_p_t = glsum(cpu_t_step /npts,1)/np
 
         if (nid.eq.0.AND.mod(istep,iocomm).eq.0) then ! conut #BDF1
           write(6,*)'newton BDFcnt: istep = ',istep
@@ -262,12 +296,13 @@ c        call compute_energy
             if (nid.eq.0) then
               write(6,*)'Writing newton.restart! at istep=',istep
               call write_paramNT
-
             endif
           endif
         endif 
 
+        time  = time + dtNT
         istep = istep+1
+
         if (lastep.eq.1) goto 901
         if (usesteps) then
           if (istep.gt.ilast) goto 901
@@ -334,7 +369,7 @@ c-----------------------------------------------------------------------
       
       call cem_drift_sem_bdf1_newton(c_in,c_out,n,iflag)
 
-      call sub3(f_out,c_out(1,iflag),c_in(1,iflag),n)
+      call sub3(f_out,c_out(1,abs(iflag)),c_in(1,abs(iflag)),n)
       call cmult(f_out,dtinv,n)
 
       return
@@ -362,7 +397,7 @@ c-----------------------------------------------------------------------
 
       do ic = 1,lcdim
         call sub3(f_out(1,ic),c_out(1,ic),c_in(1,ic),n)
-        call cmult(f_out(1,ic),dtinv,n)
+        call cmult(f_out(1,ic),1.0/dt,n)
       enddo
 
       return
@@ -418,9 +453,13 @@ c 10  format (2i8,' eps=',1p2e17.7)
       call add3s2 (uep(1,iflag),uc(1,iflag),p,1.0,eps,n) ! uep = u + eps*p
       if (isep.eq.0) then
         call compute_f_couple(fon,uep,n)
-      else
+      elseif (isep.eq.1) then 
+c        do ic = 1,lcdim
+          call compute_f_sep(fon(1,iflag),uep,iflag,n)
+c        enddo
+      elseif (isep.eq.2) then
         do ic = 1,lcdim
-          call compute_f_sep(fon(1,ic),uep,ic,n)
+          call compute_f_sep(fon(1,ic),uep,-ic,n)
         enddo
       endif
       call sub3   (foi,fon(1,iflag),fi,n)
@@ -429,6 +468,61 @@ c 10  format (2i8,' eps=',1p2e17.7)
       call sub3   (Jp,p,foi,n)
       call cmult  (Jp,dtNTinv,n)     ! Jp = p/dt_newton - (fo-f)/eps
                                              ! case with divided by dt_newton
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine JacobiMatVec_fc(Jp,p,uc,fi,n)
+c     Fully-coupled Jacobian
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'DRIFT'
+      include 'NEWTON'
+      include 'POISSON'
+
+      real     Jp(lpts1,lcdim),p(lpts1,lcdim)
+      real     uc(lpts1,lcdim)      ! variable 
+      real     fi(lpts1,lcdim)            ! parameters
+      real     uep(lpts1,lcdim)     ! uc + eps p
+      real     foi(lpts1,lcdim),fon(lpts1,lcdim)
+      integer  n,ic
+      real     eps,pnorm,unorm,glsc3 
+
+      pnorm = 0.0
+      unorm = 0.0
+      do ic=1,lcdim
+      pnorm = pnorm + glsc3(p(1,ic),p(1,ic),mult,n)
+      unorm = unorm + glsc3(uc(1,ic),uc(1,ic),mult,n)
+      enddo
+      pnorm = sqrt(pnorm)
+      unorm = sqrt(unorm)
+
+      eps = (1+unorm)*1e-14   ! formula for varing eps
+      eps = sqrt(eps)         ! for using the case using 
+                              ! "ub" filled with previous
+                              !  step info first and 
+                              !  Dirichlet info on the boundary
+      eps = eps/pnorm         ! this eps will blow up because of 
+                              ! pnorm = 0
+      epsinv = 1./eps         
+
+      do ic = 1,lcdim
+      call add3s2 (uep(1,ic),uc(1,ic),p(1,ic),1.0,eps,n) ! uep = u + eps*p
+      enddo
+
+      call compute_f_couple(fon,uep,n)
+
+      do ic=1,lcdim
+      call sub3   (foi(1,ic),fon(1,ic),fi(1,ic),n)
+      enddo
+
+      do ic=1,lcdim
+      call cmult  (foi(1,ic),epsinv*dtNT,n) ! foi = (fo-fi)*dt_newton/eps
+      call sub3   (Jp(1,ic),p(1,ic),foi(1,ic),n)
+      call cmult  (Jp(1,ic),dtNTinv,n)     ! Jp = p/dt_newton - (fo-f)/eps
+      enddo                                       ! case with divided by dt_newton
+
       return
       end
 c-----------------------------------------------------------------------
@@ -502,7 +596,7 @@ c     GMRES iteration.
 
 
 
-      integer  n,noin,outer,iflag,isep
+      integer  n,outer,iflag,isep
       real     phi(lpts1),res(lpts1),wt(lpts1)
       real     res_out,forcing,tol,alpha,l,temp
       real     eps,uc(lpts1,nion),f(lpts1)
@@ -539,7 +633,7 @@ c      tolpss= tolps
          gamma_NT(1) = glsc3(r_NT,r_NT,wt,n)                ! gamma  = (r,r)
          gamma_NT(1) = sqrt(gamma_NT(1))                 ! gamma  = sqrt{ (r,r) }
 
-         tolps = forcing*gamma_NT(1)  ! tolerance for gmres                   
+         tolps = 1E-12!forcing*gamma_NT(1)  ! tolerance for gmres                   
          tolpss = tolps        ! by using inexact Newton method
                                ! 0.1 for forcing term and is changable
 
@@ -631,191 +725,185 @@ c     call ortho   (res) ! Orthogonalize wrt null space, if present
 
       return
       end
+c-----------------------------------------------------------------------
+      subroutine drift_hmh_gmres_newton_fc
+     $           (phi_fc,res_fc,uc,f_fc,wt,nion,n,res_out,forcing)
+c     Solve the Helmholtz equation by right-preconditioned
+c     GMRES iteration.
+c     fully coupled
+c-----------------------------------------------------------------------
+      implicit none
+      include 'SIZE'
+      include 'TOTAL'
+      include 'FDMH1'
+      include 'DRIFT'
+      include 'NEWTON'
+      include 'NMGMRES'
 
-cC-----------------------------------------------------------------------
-c      subroutine drift_hmh_gmres_NTsteric(uC,fC,uref,fi,wt,nion,n,tol)
-cc-----------------------------------------------------------------------
-cc     For Steric term, involving cross term linear system 
-cc      Hii = B + dt(1 + ste_aii)*A_Di
-cc      Hij = dt*ste_aij*A_Di
-cc    
-cc      H = (Hij), f = [f1;f2;...fp], u = [u1;u2;...;up], p = # of species
-cc      
-cc     solving H*u = f
-c      implicit none
-c      include 'SIZE'
-c      include 'TOTAL'
-c      include 'FDMH1'
-c      include 'DRIFT'
-c      include 'MGMRES'
-cC
-c      integer  nion,n,outer
-c      integer  iter,iconv
-c      integer  i,j,k,m
-c      integer  ic ! safe index fo nion
-c      real     divex,etime_p,tolpss
-c
-c      real     uC(lpts1,lcdim)
-c     $       , fC(lpts1,lcdim)
-c     $       , mask(lpts1,lcdim)
-c     $       , wt(lpts1)
-c     $       , fi(lpts1,lcdim)
-c     $       , uref(lpts1,lcdim)
-c      real     tol,alpha,l,temp,rnorm
-c      real     glsc3
-c      real*8   etime1,dnekclock
-cC
-c
-c      if (nid.eq.0) write(6,*) 'start: hmh_gmres_newton_steric'
-c
-c      n = nx1*ny1*nz1*nelv
-c
-c      etime1 = dnekclock()
-c      etime_p = 0.
-c      divex = 0.
-c      iter  = 0
-c      m     = lgmres
-c
+
+
+      integer  n,nion,outer
+      real     phi_fc(lpts1,nion),res_fc(lpts1,nion),wt(lpts1)
+      real     res_out,forcing,tol,alpha,l,temp
+      real     eps,uc(lpts1,nion),f_fc(lpts1,nion)
+      real*8   etime1,dnekclock
+
+      integer  i,j,k,ic,iconv,iter,m
+      real     rnorm,tolpss
+      real     glsc3
+
+c      if (nid.eq.0) write(6,*) 'start: hmh_gmres'
+     
+      iter  = 0
+      m     = lgmres
+
 c      tolps = tol
 c      tolpss= tolps
-c      iconv = 0
-c      call rzero(xxC,lpts*(LDIMT-1))
-c      call rzero(h,m*m)
-c
-c      outer = 0
-c      do while (iconv.eq.0.and.iter.lt.5000)
-c         outer = outer+1
-c         if(iter.eq.0) then
-c            do ic=1,nion
-c            call copy  (rC(1,ic),fC(1,ic),n)      ! r = res
-c            enddo
-c         else
-c            !update residual
-c            do ic=1,nion
-c            call copy  (rC(1,ic),fC(1,ic),n)      ! r = res
-c            enddo
-c            call JacobiMatVec_steric(wC,xxC,uref,fi,n)! w = A x
-c
-c            do ic=1,nion
-c            call dssum  (wC(1,ic),nx1,ny1,nz1)
-c            call col2   (wC(1,ic),mask(1,ic),n)
-c            enddo
-c            do ic=1,nion
-c            call add2s2 (rC(1,ic),wC(1,ic),-1.,n)   ! r = r - w
-c            enddo
-c         endif
-c         gamma(1) = 0.0
-c         do ic=1,nion
-c           gamma(1) = gamma(1)+glsc3(rC(1,ic),rC(1,ic),wt,n)! gamma  = (r,r)
-c         enddo
-c         gamma(1) = sqrt(gamma(1))                 ! gamma  = sqrt{ (r,r) }
-c         write(6,*) 'initial residule',gamma(1)
-c                                                   !      1     include 'SIZE'
-c
-c         !check for lucky convergence
-c         rnorm = 0.
-c         if(gamma(1) .eq. 0.) goto 9000
-c         temp = 1./gamma(1)
-c         do ic=1,nion
-c         call cmult2(vC(1,ic,1),rC(1,ic),temp,n)            !  v  = r / gamma
-c         enddo
-c         !write(6,*) 'start form m-th krylov subspace'
-c         do j=1,m
-c            iter = iter+1
-c            call JacobiMatVec_steric(wC,vC(1,1,j),uref,fi,n)! w = A v 
-c            do ic=1,nion
-c            call dssum  (wC(1,ic),nx1,ny1,nz1)
-c            call col2   (wC(1,ic),mask(1,ic),n)
-c            enddo
-c
-cc           !modified Gram-Schmidt
-c            do i=1,j
-c               h(i,j)=0.0
-c               do ic=1,nion
-c               h(i,j) = h(i,j) + glsc3(wC(1,ic),vC(1,ic,i),wt,n) ! h    = (w,v )
-c               enddo                                             ! i,j       i
-c               do ic=1,nion
-c               call add2s2(wC(1,ic),vC(1,ic,i),-h(i,j),n)   ! w = w - h    v
-c               enddo                                        !         i,j  i
-c            enddo
-c
-c            !apply Givens rotations to new column
-c            do i=1,j-1
-c               temp = h(i,j)
-c               h(i  ,j)=  c(i)*temp + s(i)*h(i+1,j)
-c               h(i+1,j)= -s(i)*temp + c(i)*h(i+1,j)
-c            enddo
-c            alpha=0.0
-c            do ic=1,nion
-c            alpha = alpha + glsc3(wC(1,ic),wC(1,ic),wt,n)  !            ______
-c            enddo                                          ! alpha =  \/ (w,w)
-c            alpha=sqrt(alpha)
-c
-c            if(alpha.eq.0.) goto 900  !converged
-c            l = sqrt(h(j,j)*h(j,j)+alpha*alpha)
-c            temp = 1./l
-c            c(j) = h(j,j) * temp
-c            s(j) = alpha  * temp
-c            h(j,j) = l
-c            gamma(j+1) = -s(j) * gamma(j)
-c            gamma(j)   =  c(j) * gamma(j)
-c
-c            rnorm = abs(gamma(j+1))!*norm_fac     
-cc           ratio = rnorm/div0
-c            if ((nid.eq.0).and.(istep.le.5))
+      iconv = 0
+      
+      call rzero(x_NT,lpts1*(LDIMT-1))
+      call rzero(h_NT,m*m)
+
+      outer = 0
+      do while (iconv.eq.0.and.iter.lt.500)
+         outer = outer+1
+         if(iter.eq.0) then
+            do ic = 1,nion
+            call copy  (r_NT(1,ic),res_fc(1,ic),n)                  ! r = res
+            enddo
+         else
+            !update residual
+            do ic=1,nion
+            call copy   (r_NT(1,ic),res_fc(1,ic),n)                  ! r = res
+            enddo
+            call JacobiMatVec_fc(w_NT,x_NT,uc,f_fc,n)! w = A x
+            do ic=1,nion
+            call add2s2 (r_NT(1,ic),w_NT(1,ic),-1.,n) ! r = r - w
+            enddo
+         endif
+
+         gamma_NT(1) = 0.0
+         do ic=1,nion
+         gamma_NT(1) = gamma_NT(1)
+     $               + glsc3(r_NT(1,ic),r_NT(1,ic),wt,n)                ! gamma  = (r,r)
+         enddo
+         gamma_NT(1) = sqrt(gamma_NT(1))                 ! gamma  = sqrt{ (r,r) }
+
+         tolps = forcing*gamma_NT(1)  ! tolerance for gmres                   
+c         tolps = 1E-10 ! exact Newton,Lan
+         tolpss = tolps        ! by using inexact Newton method
+                               ! 0.1 for forcing term and is changable
+
+         !check for lucky convergence
+         rnorm = 0.
+         if(gamma_NT(1) .eq. 0.) goto 9000
+         temp = 1./gamma_NT(1)
+         do ic=1,nion
+         call cmult2(v_NT(1,ic,1),r_NT(1,ic),temp,n)             !  v  = r / gamma
+         enddo
+                                                  !  1            1
+         !write(6,*) 'start form m-th krylov subspace'
+         do j=1,m
+            iter = iter+1
+
+            call JacobiMatVec_fc(w_NT,v_NT(1,1,j),uc,f_fc,n) ! w = A v
+
+            !modified Gram-Schmidt
+            do i=1,j
+               h_NT(i,j)=0.0
+               do ic=1,nion
+               h_NT(i,j)=h_NT(i,j)
+     $                  +glsc3(w_NT(1,ic),v_NT(1,ic,i),wt,n)        ! h    = (w,v )
+               enddo                                   ! i,j       i
+               do ic=1,nion
+               call add2s2(w_NT(1,ic),v_NT(1,ic,i),-h_NT(i,j),n)    ! w = w - h    v
+               enddo
+            enddo                                 !         i,j  i
+
+
+            !apply Givens rotations to new column
+            do i=1,j-1
+               temp = h_NT(i,j)
+               h_NT(i  ,j)=  c_NT(i)*temp + s_NT(i)*h_NT(i+1,j)
+               h_NT(i+1,j)= -s_NT(i)*temp + c_NT(i)*h_NT(i+1,j)
+            enddo
+            alpha = 0.0
+            do ic=1,nion                               !            ______
+            alpha = alpha + glsc3(w_NT(1,ic),w_NT(1,ic),wt,n)     ! alpha =  \/ (w,w)
+            enddo
+            alpha = sqrt(alpha)
+
+            if(alpha.eq.0.) goto 900 !converged
+            l = sqrt(h_NT(j,j)*h_NT(j,j)+alpha*alpha)
+            temp = 1./l
+            c_NT(j) = h_NT(j,j) * temp
+            s_NT(j) = alpha  * temp
+            h_NT(j,j) = l
+            gamma_NT(j+1) = -s_NT(j) * gamma_NT(j)
+            gamma_NT(j)   =  c_NT(j) * gamma_NT(j)
+
+            rnorm = abs(gamma_NT(j+1))
+
+c            if ((nid.eq.0).and.(istep.le.2))
 c     $           write (6,66) iter,tolpss,rnorm,istep
-c   66       format(i5,1p2e12.5,i8,' Divergence')
-c
-c            if (rnorm .lt. tolps) goto 900 !converged
-c            if (j.eq.m) goto 1000 !not converged, restart
-c
-c            temp = 1./alpha
-c            do ic=1,nion
-c            call cmult2(vC(1,ic,j+1),wC(1,ic),temp,n)   ! v    = w / alpha
-c            enddo                                       !  j+1
-c         enddo
-cc        write(6,*) 'end of forming m-th krylov subspace'
-c  900    iconv = 1
-c 1000    continue
-c
-cc        back substitution
-cc             -1
-cc        c = H   gamma
-cc        write(6,*) 'start solving least squre problem'
-c         do k=j,1,-1
-c            temp = gamma(k)
-c            do i=j,k+1,-1
-c               temp = temp - h(k,i)*c(i)
-c            enddo
-c            c(k) = temp/h(k,k)
-c         enddo
-c         !sum up Arnoldi vectors
-c         do i=1,j
-c            do ic=1,nion
-c            call add2s2(xxC(1,ic),vC(1,ic,i),c(i),n)  ! x = x + c  z
-c            enddo                                      !  i  i
-c         enddo
-cc        write(6,*) 'end of solving least squre problem'
-c      enddo
-c 9000 continue
-c
-c       do ic=1,nion
-c       call copy(uC(1,ic),xxC(1,ic),n)
-c       enddo
-c
-cc      call ortho   (res) ! Orthogonalize wrt null space, if present
-c
-c      etime1 = dnekclock()-etime1
-c      if (nid.eq.0) then
-c          if ((mod(istep,iocomm).eq.0).or.(istep.le.10))
-c     $    write(6,9999) istep,iter,tolpss,etime_p,etime1
-c      endif
-c 9999 format(' ',' ',i9,' gmres   : iteration#',i5,1p3e12.4)
-c
-c      return
-c      end
+   66       format(i5,1p2e12.5,i8,' gmres_newton rnorm')
+
+            if (rnorm .lt. tolps) goto 900 !converged
+            if (j.eq.m) goto 1000 !not converged, restart
+
+            temp = 1./alpha
+            do ic=1,nion
+            call cmult2(v_NT(1,ic,j+1),w_NT(1,ic),temp,n)   ! v    = w / alpha
+            enddo                                 !  j+1
+         enddo
+c        write(6,*) 'end of forming m-th krylov subspace'
+  900    iconv = 1
+         res_out = rnorm   ! output |Ax-b|
+         if (nid.eq.0) write(6,*) istep,iterNT,
+     $                 'forcing_term',rnorm/tolpss
+ 1000    continue
+
+c        back substitution
+c             -1
+c        c = H   gamma
+c        write(6,*) 'start solving least squre problem'
+         do k=j,1,-1
+            temp = gamma_NT(k)
+            do i=j,k+1,-1
+               temp = temp - h_NT(k,i)*c_NT(i)
+            enddo
+            c_NT(k) = temp/h_NT(k,k)
+         enddo
+         !sum up Arnoldi vectors
+         do i=1,j
+            do ic=1,nion
+            call add2s2(x_NT(1,ic),v_NT(1,ic,i),c_NT(i),n)     ! x = x + c  z
+            enddo
+         enddo                               !          i  i
+c     write(6,*) 'end of solving least squre problem'
+      enddo
+ 9000 continue
+
+      do ic=1,nion
+      call copy(phi_fc(1,ic),x_NT(1,ic),n)
+      enddo
+
+c     call ortho   (res) ! Orthogonalize wrt null space, if present
+
+      if ((nid.eq.0).and. (mod(istep,iocomm).eq.0) ) then
+          write(6,9999) istep,iterNT,iter,tolpss
+      endif
+
+ 9999 format(' ',' ',i9,i6,'  gmres_newton_iteration#',i6,1p1e12.4)
+
+      return
+      end
 c---------------------------------------------------------------------
       subroutine cem_drift_sem_bdf1_newton(cinput,coutput,n,iflag)
+c     Three mode: (switch iflag)
+c      0 couple:        update all the fields: cN(s) and potent
+c      i separate:      update potent and one of cN(i)
+c     -i fully-separate:update potent(-1) or cN(-2) or cP(-3)
 c---------------------------------------------------------------------
       implicit none
       include 'SIZE'
@@ -829,25 +917,33 @@ c---------------------------------------------------------------------
       real cinput(lpts1,lcdim)
       real coutput(lpts1,lcdim)
 
-      do ic = 1,lcdim
+      do ic = 1,lcdim ! copy in
         call copy(cN(1,ic),cinput(1,ic),n)
       enddo
+
       if (iflag.eq.0) then ! coupling every thing
+
         call cem_drift_op_bdf
         do ic = 1,lcdim+1
           BDFcnt(ic) = BDFcnt(ic) + 1
         enddo
-      else ! seperate
+
+      elseif (iflag.gt.0) then ! seperate
+
         call cem_drift_source
         call cem_drift_poisson
-        call cem_drift_sem_bdf1_init
         BDFcnt(1) = BDFcnt(1) + 1
 
+        call cem_drift_sem_bdf1_init
         call cem_drift_rhs_bdf1(iflag)
         call cem_drift_lhs_bdf1(iflag)
         BDFcnt(iflag+1) = BDFcnt(iflag+1) + 1
+
+      else                 ! fully-separate
+
       endif
-      do ic = 1,lcdim
+
+      do ic = 1,lcdim ! copy out
         call copy(coutput(1,ic),cN(1,ic),n)
       enddo
 
@@ -1066,7 +1162,7 @@ C     Read paramNT
 C     Set paramNT
 
       ! 1~7 Pseudo-timestep
-      ifsep    = int(paramNT(3))   ! (int) 0=couple, 1=separate, Lan
+      ifsep    = int(paramNT(3))   ! (int) 0=couple, 1=separate
       dtNT     = paramNT(4)        ! pseudo-transient time step
       max_dtNT = paramNT(5)        ! Max. of dtNT, avoid NaN
       min_ftol = paramNT(6)        ! Min. of f_pre, avoid NaN


### PR DESCRIPTION
To observe quadratic convergence
- turn ifsep = -1 to use fully couppled mode
- comment "forcing" in gmres_newton_fc to get rid of inexact Newton
- unomment the checking subroutine in the newton loop

Fix the order of compute_f and compute_g
- dtNT is updated inside gn_n
- If dt changes, update f

Add new criterion for Newton loop
- if |sk| is too small, goto next newton loop instead of stalling